### PR TITLE
Configure Continuous Integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,4 @@ fastlane/test_output
 iOSInjectionProject/
 
 .DS_Store
+.xcov_output

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: swift
+os: osx
+osx_image: xcode10.1
+
+notifications:
+  email: false
+
+script:
+  - |
+    set -o pipefail && xcodebuild test \
+      -workspace Time.xcworkspace \
+      -scheme Shared-Tests \
+      -sdk macosx10.14 \
+      CODE_SIGN_IDENTITY="" \
+      CODE_SIGNING_REQUIRED=NO \
+      | xcpretty

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ before_install:
   - brew tap homebrew/services
   - brew services start mysql@5.7
   - brew link mysql@5.7 --force
+  - gem install xcov
 
 install:
   # Clone API and merge current source with cached node_modules.
@@ -40,3 +41,14 @@ script:
       CODE_SIGN_IDENTITY="" \
       CODE_SIGNING_REQUIRED=NO \
       | xcpretty
+
+after_success:
+  - |
+    xcov \
+    -w Time.xcworkspace \
+    -s Shared-Tests \
+    --json_report \
+    --skip_slack \
+    -o xcov_output \
+    --coveralls_service_name travis-ci \
+    --coveralls_service_job_id $TRAVIS_JOB_ID

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,25 @@ env:
     - DB_PASS=
     - DB_NAME=timetest
 
+cache:
+  directories:
+    - Time-API/node_modules
+
 before_install:
   - brew install mysql@5.7
   - brew tap homebrew/services
   - brew services start mysql@5.7
   - brew link mysql@5.7 --force
-  - git clone --depth 1 git://github.com/Tornquist/Time-API.git
+
+install:
+  # Clone API and merge current source with cached node_modules.
+  - git clone --depth 1 git://github.com/Tornquist/Time-API.git api
+  - cp -a api/. Time-API/
+  - rm -rf api
+  # Install API dependencies. Create and migrate database.
   - (cd Time-API && npm install)
   - (cd Time-API && scripts/setup-travis.sh)
+  - (cd Time-API && npm start &) && sleep 2
 
 script:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,21 @@ osx_image: xcode10.1
 notifications:
   email: false
 
+env:
+  global:
+    - DB_USER=root
+    - DB_PASS=
+    - DB_NAME=timetest
+
+before_install:
+  - brew install mysql@5.7
+  - brew tap homebrew/services
+  - brew services start mysql@5.7
+  - brew link mysql@5.7 --force
+  - git clone --depth 1 git://github.com/Tornquist/Time-API.git
+  - (cd Time-API && npm install)
+  - (cd Time-API && scripts/setup-travis.sh)
+
 script:
   - |
     set -o pipefail && xcodebuild test \

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Time-Client
 
+[![Build Status](https://travis-ci.com/Tornquist/Time-Client.svg?branch=master)](https://travis-ci.com/Tornquist/Time-Client)
+
 Time is a multipurpose time and event tracking system.
 
 This repository contains logic for the iOS and macOS client applications.

--- a/Shared/Shared.xcodeproj/project.pbxproj
+++ b/Shared/Shared.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		D855818421BDEB6400DCB577 /* Time_Shared.h in Headers */ = {isa = PBXBuildFile; fileRef = D855818221BDEB6400DCB577 /* Time_Shared.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D85581AD21BEABC300DCB577 /* EntryType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85581AB21BEABC300DCB577 /* EntryType.swift */; };
 		D85581D821C14D6700DCB577 /* Time.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D855818021BDEB6400DCB577 /* Time.framework */; };
+		D8FE621A22062549003A095A /* Test_0_Setup.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FE621922062549003A095A /* Test_0_Setup.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -63,6 +64,7 @@
 		D85581AB21BEABC300DCB577 /* EntryType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryType.swift; sourceTree = "<group>"; };
 		D85581D321C14D6700DCB577 /* Shared-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Shared-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D85581D721C14D6700DCB577 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D8FE621922062549003A095A /* Test_0_Setup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test_0_Setup.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -159,6 +161,7 @@
 			isa = PBXGroup;
 			children = (
 				D85581D721C14D6700DCB577 /* Info.plist */,
+				D8FE621922062549003A095A /* Test_0_Setup.swift */,
 				D811B17521E38CD3009F6C8E /* Test_Authentication.swift */,
 				D8437C5A21F3B04700974B03 /* Test_Token.swift */,
 				D8437C5F21F4C8C800974B03 /* Test_TokenStore.swift */,
@@ -297,6 +300,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D8FE621A22062549003A095A /* Test_0_Setup.swift in Sources */,
 				D8437C5B21F3B04700974B03 /* Test_Token.swift in Sources */,
 				D811B17921E62B81009F6C8E /* Test_API_Tokens.swift in Sources */,
 				D811B17F21EA451E009F6C8E /* Test_API_Accounts.swift in Sources */,

--- a/Shared/Shared.xcodeproj/xcshareddata/xcschemes/Shared-Tests.xcscheme
+++ b/Shared/Shared.xcodeproj/xcshareddata/xcschemes/Shared-Tests.xcscheme
@@ -5,11 +5,28 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D85581D221C14D6700DCB577"
+               BuildableName = "Shared-Tests.xctest"
+               BlueprintName = "Shared-Tests"
+               ReferencedContainer = "container:Shared.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      codeCoverageEnabled = "YES"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -36,6 +53,15 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D85581D221C14D6700DCB577"
+            BuildableName = "Shared-Tests.xctest"
+            BlueprintName = "Shared-Tests"
+            ReferencedContainer = "container:Shared.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
@@ -45,6 +71,15 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D85581D221C14D6700DCB577"
+            BuildableName = "Shared-Tests.xctest"
+            BlueprintName = "Shared-Tests"
+            ReferencedContainer = "container:Shared.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Shared/Tests/Test_0_Setup.swift
+++ b/Shared/Tests/Test_0_Setup.swift
@@ -1,0 +1,39 @@
+//
+//  Test_0_Setup.swift
+//  Shared-Tests
+//
+//  Created by Nathan Tornquist on 2/2/19.
+//  Copyright © 2019 nathantornquist. All rights reserved.
+//
+
+import XCTest
+@testable import Time
+
+class Test_0_Setup: XCTestCase {
+    
+    func test_createDefaultUserIfNeeded() {
+        let api = API()
+        
+        let email = "test@test.com"
+        let password = "defaultPassword"
+        
+        var userExists = false
+        
+        // Attempt to log user in
+        let loginUserExpectation = self.expectation(description: "loginUser")
+        api.getToken(withUsername: email, andPassword: password) { (token, error) in
+            userExists = token != nil
+            loginUserExpectation.fulfill()
+        }
+        waitForExpectations(timeout: 5, handler: nil)
+        
+        guard !userExists else { return }
+
+        // Attempt to create user if needed
+        let createUserExpectation = self.expectation(description: "createUser")
+        API.shared.createUser(withEmail: email, andPassword: password) { (user, error) in
+            createUserExpectation.fulfill()
+        }
+        waitForExpectations(timeout: 5, handler: nil)
+    }
+}

--- a/Shared/Tests/Test_API_Accounts.swift
+++ b/Shared/Tests/Test_API_Accounts.swift
@@ -13,23 +13,26 @@ import XCTest
 
 class Test_API_Accounts: XCTestCase {
     
-    override func setUp() { }
+    override func setUp() {
+        self.continueAfterFailure = false
+        
+        let getTokenExpectation = self.expectation(description: "getToken")
+        API.shared.getToken(withUsername: "test@test.com", andPassword: "defaultPassword") { (token, error) in
+            XCTAssertNotNil(token)
+            getTokenExpectation.fulfill()
+        }
+        waitForExpectations(timeout: 5, handler: nil)
+    }
     
     override func tearDown() { }
 
     func test_getToken_createAccount() {
         let expectation = self.expectation(description: "createAccount")
-        
-        API.shared.getToken(withUsername: "test@test.com", andPassword: "defaultPassword") { (token, error) in
-
-            XCTAssertNotNil(token)
-            
-            API.shared.createAccount() { (account, error) in
-                XCTAssertNotNil(account)
-                XCTAssertNil(error)
+        API.shared.createAccount() { (account, error) in
+            XCTAssertNotNil(account)
+            XCTAssertNil(error)
                 
-                expectation.fulfill()
-            }
+            expectation.fulfill()
         }
         
         waitForExpectations(timeout: 5, handler: nil)
@@ -37,19 +40,12 @@ class Test_API_Accounts: XCTestCase {
     
     func test_getToken_getAccounts() {
         let expectation = self.expectation(description: "getAccounts")
-        
-        API.shared.getToken(withUsername: "test@test.com", andPassword: "defaultPassword") { (token, error) in
+        API.shared.getAccounts() { (accounts, error) in
+            XCTAssertNotNil(accounts)
+            XCTAssertNil(error)
             
-            XCTAssertNotNil(token)
-            
-            API.shared.getAccounts() { (accounts, error) in
-                XCTAssertNotNil(accounts)
-                XCTAssertNil(error)
-                
-                expectation.fulfill()
-            }
+            expectation.fulfill()
         }
-        
         waitForExpectations(timeout: 5, handler: nil)
     }
 }

--- a/Shared/Tests/Test_API_Tokens.swift
+++ b/Shared/Tests/Test_API_Tokens.swift
@@ -48,21 +48,26 @@ class Test_API_Tokens: XCTestCase {
     }
     
     func test_refreshToken_validRefresh() {
-        let expectation = self.expectation(description: "refreshToken")
+        self.continueAfterFailure = false
         
+        var startingToken: Token? = nil
+        let getExpectation = self.expectation(description: "getToken")
         API.shared.getToken(withUsername: "test@test.com", andPassword: "defaultPassword") { (authToken, error) in
-            XCTAssertNotNil(authToken)
+            startingToken = authToken
             
-            API.shared.refreshToken() { (refreshedToken, error) in
-                XCTAssertNotNil(refreshedToken)
-                XCTAssertNil(error)
-                
-                XCTAssertNotEqual(authToken!.token, refreshedToken!.token)
-                
-                expectation.fulfill()
-            }
+            XCTAssertNotNil(authToken)
+            getExpectation.fulfill()
         }
+        waitForExpectations(timeout: 5, handler: nil)
         
+        let refreshExpectation = self.expectation(description: "refreshToken")
+        API.shared.refreshToken() { (refreshedToken, error) in
+            XCTAssertNotNil(refreshedToken)
+            XCTAssertNil(error)
+            
+            XCTAssertNotEqual(startingToken!.token, refreshedToken!.token)
+            refreshExpectation.fulfill()
+        }
         waitForExpectations(timeout: 5, handler: nil)
     }
     

--- a/Shared/Tests/Test_Authentication.swift
+++ b/Shared/Tests/Test_Authentication.swift
@@ -60,7 +60,11 @@ class Test_Authentication: XCTestCase {
     }
     
     func test_3_authenticatedTokenExpiresInFuture() {
-        let expiration = self.api.token!.expiration
+        guard let expiration = self.api.token?.expiration else {
+            XCTFail("Token expiration not found")
+            return
+        }
+        
         let now = Date()
         
         XCTAssertLessThan(now, expiration)


### PR DESCRIPTION
# 💚 Summary

* Add `.travis.yml` with configuration to:
    * Install and configure mysql 5.7
    * Setup `Time-API` build on master
    * Use `xcov` to collect coverage results and send to `coveralls.io`
        * Note: Currently results display 80% in travis, and 0% on coveralls. Multiple errors reported on coveralls and on xcov. Results are visible in xcode, so I'm fine moving ahead with this broken. This issue is out of my hands. Because of this, I'm leaving the coveralls badge off the repo for now.
* Update `Time-Client` tests to run without networking (and avoid any exceptions that would crash the test suite0
* Add setup test class to optionally create users downstream tests depend on. If this fails, other downstream tests will also fail.
