### PR TITLE
Codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,3 @@
+coverage:
+  ignore:
+    - "Shared/Tests/*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ before_install:
   - brew tap homebrew/services
   - brew services start mysql@5.7
   - brew link mysql@5.7 --force
-  - gem install xcov
 
 install:
   # Clone API and merge current source with cached node_modules.
@@ -43,15 +42,4 @@ script:
       | xcpretty
 
 after_success:
-  # Coveralls
-  - |
-    xcov \
-    -w Time.xcworkspace \
-    -s Shared-Tests \
-    --json_report \
-    --skip_slack \
-    -o xcov_output \
-    --coveralls_service_name travis-ci \
-    --coveralls_service_job_id $TRAVIS_JOB_ID
-  # Codecov
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ script:
       | xcpretty
 
 after_success:
+  # Coveralls
   - |
     xcov \
     -w Time.xcworkspace \
@@ -52,3 +53,5 @@ after_success:
     -o xcov_output \
     --coveralls_service_name travis-ci \
     --coveralls_service_job_id $TRAVIS_JOB_ID
+  # Codecov
+  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Time-Client
 
-[![Build Status](https://travis-ci.com/Tornquist/Time-Client.svg?branch=master)](https://travis-ci.com/Tornquist/Time-Client)
+[![Build Status](https://travis-ci.com/Tornquist/Time-Client.svg?branch=master)](https://travis-ci.com/Tornquist/Time-Client) [![codecov](https://codecov.io/gh/Tornquist/Time-Client/branch/master/graph/badge.svg)](https://codecov.io/gh/Tornquist/Time-Client)
 
 Time is a multipurpose time and event tracking system.
 


### PR DESCRIPTION
# 💚 Summary

* Add codecov
* Remove coveralls

## Details

After thinking about it, I decided that I would rather have consistent historical coverage reports than necessarily have all the reports in the same place. I didn't want to continue having coveralls reporting 0% on every PR, and I didn't want conflicting numbers from two different reporting services.

It's extremely easy to integrate coverage with swift on codecov, so that'll be the direction day forward. I'm keeping the `API` and `Core` repos on coveralls. I much prefer the coveralls UI.