### PR TITLE
Complete API

### DIFF
--- a/Shared/Network/API+Routes.swift
+++ b/Shared/Network/API+Routes.swift
@@ -54,6 +54,10 @@ extension API {
         GET("/accounts", completion: completionHandler)
     }
     
+    func getAccount(withID id: Int, completionHandler: @escaping (Account?, Error?) -> ()) {
+        GET("/accounts/\(id)", completion: completionHandler)
+    }
+    
     // MARK: - Categories
     
     func getCategories(completionHandler: @escaping ([Category]?, Error?) -> ()) {

--- a/Shared/Network/API+Routes.swift
+++ b/Shared/Network/API+Routes.swift
@@ -44,6 +44,16 @@ extension API {
         POST("/users", ["email": email, "password": password], auth: false, completion: completionHandler)
     }
     
+    func updateUser(withID id: Int, setEmail email: String, completionHandler: @escaping (User?, Error?) -> ()) {
+        let body: [String: Any] = ["email": email]
+        PUT("/users/\(id)", body, completion: completionHandler)
+    }
+    
+    func updateUser(withID id: Int, changePasswordFrom oldPassword: String, to newPassword: String, completionHandler: @escaping (User?, Error?) -> ()) {
+        let body: [String: Any] = ["old_password": oldPassword, "new_password": newPassword]
+        PUT("/users/\(id)", body, completion: completionHandler)
+    }
+    
     // MARK: - Accounts
     
     func createAccount(completionHandler: @escaping (Account?, Error?) -> ()) {

--- a/Shared/Network/API+Routes.swift
+++ b/Shared/Network/API+Routes.swift
@@ -70,10 +70,26 @@ extension API {
         POST("/categories", body, auth: true, encoding: .json, completion: completionHandler)
     }
     
+    func getCategory(withID id: Int, completionHandler: @escaping (Category?, Error?) -> ()) {
+        GET("/categories/\(id)", completion: completionHandler)
+    }
+    
     func moveCategory(_ category: Category, toParent parent: Category, completionHandler: @escaping (Category?, Error?) -> ()) {
         let body: [String: Any] = ["parent_id": parent.id, "account_id": parent.accountID]
         
         PUT("/categories/\(category.id)", body, completion: completionHandler)
+    }
+    
+    func renameCategory(_ category: Category, withName name: String, completionHandler: @escaping (Category?, Error?) -> ()) {
+        let body: [String: Any] = ["name": name]
+        
+        PUT("/categories/\(category.id)", body, completion: completionHandler)
+    }
+    
+    func deleteCategory(withID id: Int, andChildren deleteChildren: Bool, completionHandler: @escaping (Error?) -> ()) {
+        let body: [String: Any] = ["delete_children": deleteChildren]
+
+        DELETE("/categories/\(id)", body, completion: completionHandler)
     }
     
     // MARK: - Entries

--- a/Shared/Network/API.swift
+++ b/Shared/Network/API.swift
@@ -53,7 +53,7 @@ class API: APIQueueDelegate {
         self.timeRequest(path: pathComponent, method: .PUT, body: body, encoding: .json, authorized: true, completion: completion, sideEffects: sideEffects)
     }
     
-    func DELETE(_ pathComponent: String, completion: @escaping (Error?) -> ()) {
+    func DELETE(_ pathComponent: String, _ body: [String: Any]? = nil, completion: @escaping (Error?) -> ()) {
         let internalCompletion = { (success: Success?, error: Error?) in
             guard error == nil else { completion(error); return }
             let result = success?.success ?? false
@@ -61,7 +61,9 @@ class API: APIQueueDelegate {
             completion(finalError)
         }
         
-        self.timeRequest(path: pathComponent, method: .DELETE, body: nil, encoding: nil, authorized: true, completion: internalCompletion, sideEffects: nil)
+        let encoding = body != nil ? HttpEncoding.json : nil
+        
+        self.timeRequest(path: pathComponent, method: .DELETE, body: body, encoding: encoding, authorized: true, completion: internalCompletion, sideEffects: nil)
     }
 
     func timeRequest<T>(path pathComponent: String, method: HttpMethod, body: [String: Any]?, encoding: HttpEncoding?, authorized: Bool, completion: @escaping (T?, Error?) -> (), sideEffects: ((T) -> ())? = nil) where T : Decodable {
@@ -191,7 +193,8 @@ class API: APIQueueDelegate {
         
         switch (method, encoding) {
         case (HttpMethod.POST, HttpEncoding.json),
-             (HttpMethod.PUT, HttpEncoding.json):
+             (HttpMethod.PUT, HttpEncoding.json),
+             (HttpMethod.DELETE, HttpEncoding.json):
             headers["Content-Type"] = "application/json"
             guard let httpBody = try? JSONSerialization.data(withJSONObject: body, options: JSONSerialization.WritingOptions.prettyPrinted) else {
                 throw TimeError.unableToSendRequest("Cannot encode body")

--- a/Shared/Tests/Test_API_Accounts.swift
+++ b/Shared/Tests/Test_API_Accounts.swift
@@ -11,6 +11,8 @@ import XCTest
 
 class Test_API_Accounts: XCTestCase {
     
+    static var accountID: Int? = nil
+    
     override func setUp() {
         self.continueAfterFailure = false
         
@@ -24,7 +26,7 @@ class Test_API_Accounts: XCTestCase {
     
     override func tearDown() { }
 
-    func test_getToken_createAccount() {
+    func test_createAccount() {
         let expectation = self.expectation(description: "createAccount")
         API.shared.createAccount() { (account, error) in
             XCTAssertNotNil(account)
@@ -36,10 +38,30 @@ class Test_API_Accounts: XCTestCase {
         waitForExpectations(timeout: 5, handler: nil)
     }
     
-    func test_getToken_getAccounts() {
+    func test_getAccounts() {
         let expectation = self.expectation(description: "getAccounts")
         API.shared.getAccounts() { (accounts, error) in
             XCTAssertNotNil(accounts)
+            XCTAssertNil(error)
+            
+            if accounts != nil && accounts!.count > 0 {
+                Test_API_Accounts.accountID = accounts![0].id
+            }
+            
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 5, handler: nil)
+    }
+    
+    func test_getSingleAccounts() {
+        guard let accountID = Test_API_Accounts.accountID else {
+            XCTFail("Dependent on accountID. Unable to perform test")
+            return
+        }
+        
+        let expectation = self.expectation(description: "getAccount")
+        API.shared.getAccount(withID: accountID) { (account, error) in
+            XCTAssertNotNil(account)
             XCTAssertNil(error)
             
             expectation.fulfill()

--- a/Shared/Tests/Test_API_Users.swift
+++ b/Shared/Tests/Test_API_Users.swift
@@ -11,6 +11,19 @@ import XCTest
 
 class Test_API_Users: XCTestCase {
     
+    static var tokenTag = "test-users-tests"
+    static var api: API!
+    static var time: Time!
+    
+    var tokenTag: String { return Test_API_Users.tokenTag }
+    var api: API! { return Test_API_Users.api }
+    var time: Time! { return Test_API_Users.time }
+    
+    override class func setUp() {
+        Test_API_Users.api = API()
+        Test_API_Users.time = Time(withAPI: Test_API_Users.api, andTokenIdentifier: self.tokenTag)
+    }
+    
     override func setUp() { }
     
     override func tearDown() { }
@@ -22,8 +35,8 @@ class Test_API_Users: XCTestCase {
         let email = "\(uuid)@time.com"
         let password = "defaultPassword"
         
-        API.shared.createUser(withEmail: email, andPassword: password) { (user, error) in
-            XCTAssertNotNil(user)
+        API.shared.createUser(withEmail: email, andPassword: password) { (newUser, error) in
+            XCTAssertNotNil(newUser)
             XCTAssertNil(error)
             
             expectation.fulfill()
@@ -89,6 +102,106 @@ class Test_API_Users: XCTestCase {
             expectation.fulfill()
         }
         
+        waitForExpectations(timeout: 5, handler: nil)
+    }
+    
+    func test_allowsEmailToBeChanged() {
+        self.continueAfterFailure = false
+        
+        let email = "\(UUID().uuidString)@time.com"
+        let newEmail = "\(UUID().uuidString)@time.com"
+        let password = "defaultPassword"
+        
+        // Configure User
+        let createExpectation = self.expectation(description: "createUser")
+
+        var user: User! = nil
+        api.createUser(withEmail: email, andPassword: password) { (newUser, error) in
+            XCTAssertNotNil(newUser)
+            XCTAssertNil(error)
+            user = newUser
+            
+            XCTAssertEqual(newUser?.email, email)
+            
+            createExpectation.fulfill()
+        }
+        
+        waitForExpectations(timeout: 5, handler: nil)
+        
+        // Login User
+        let loginExpectation = self.expectation(description: "loginUser")
+        api.getToken(withUsername: email, andPassword: password) { (token, error) in
+            loginExpectation.fulfill()
+        }
+        waitForExpectations(timeout: 5, handler: nil)
+        
+        // Update User
+        let updateExpectation = self.expectation(description: "updateUser")
+        api.updateUser(withID: user.id, setEmail: newEmail) { (user, error) in
+            XCTAssertNotNil(user)
+            XCTAssertNil(error)
+            
+            XCTAssertEqual(user?.email, newEmail)
+            
+            updateExpectation.fulfill()
+        }
+        waitForExpectations(timeout: 5, handler: nil)
+        
+        // Login with new credentials
+        let reloginExpectation = self.expectation(description: "loginUser")
+        api.getToken(withUsername: newEmail, andPassword: password) { (token, error) in
+            XCTAssertNotNil(token)
+            reloginExpectation.fulfill()
+        }
+        waitForExpectations(timeout: 5, handler: nil)
+    }
+    
+    func test_allowsPasswordToBeChanged() {
+        self.continueAfterFailure = false
+        
+        let email = "\(UUID().uuidString)@time.com"
+        let password = "defaultPassword"
+        let newPassword = "brandNewPassword"
+        
+        // Configure User
+        let createExpectation = self.expectation(description: "createUser")
+        
+        var user: User! = nil
+        api.createUser(withEmail: email, andPassword: password) { (newUser, error) in
+            XCTAssertNotNil(newUser)
+            XCTAssertNil(error)
+            user = newUser
+            
+            XCTAssertEqual(newUser?.email, email)
+            
+            createExpectation.fulfill()
+        }
+        
+        waitForExpectations(timeout: 5, handler: nil)
+        
+        // Login User
+        let loginExpectation = self.expectation(description: "loginUser")
+        api.getToken(withUsername: email, andPassword: password) { (token, error) in
+            loginExpectation.fulfill()
+        }
+        waitForExpectations(timeout: 5, handler: nil)
+        
+        // Update User
+        let updateExpectation = self.expectation(description: "updateUser")
+        api.updateUser(withID: user.id, changePasswordFrom: password, to: newPassword) { (user, error) in
+            XCTAssertNotNil(user)
+            XCTAssertNil(error)
+            
+            updateExpectation.fulfill()
+        }
+        waitForExpectations(timeout: 5, handler: nil)
+        
+        // Login with new credentials
+        let reloginExpectation = self.expectation(description: "loginUser")
+        api.getToken(withUsername: email, andPassword: newPassword) { (token, error) in
+            XCTAssertNotNil(token)
+            reloginExpectation.fulfill()
+        }
         waitForExpectations(timeout: 5, handler: nil)
     }
 }


### PR DESCRIPTION
# :green_heart: Summary

* Add remaining API methods for parity with current Time-API
    * updateUser (email, password)
    * getAccount
    * getCategory
    * renameCategory
    * deleteCategory
* Add ability to send a body with `DELETE` requests