### PR TITLE
Matrix Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,15 @@ osx_image: xcode10.1
 notifications:
   email: false
 
+matrix:
+  include:
+    - env:
+      - SCHEME=Shared-Tests-macOS
+      - DESTINATION="platform=macOS,arch=x86_64"
+    - env:
+      - SCHEME=Shared-Tests-iOS
+      - DESTINATION="platform=iOS Simulator,name=iPhone X,OS=12.1"
+
 env:
   global:
     - DB_USER=root
@@ -36,15 +45,8 @@ script:
     set -o pipefail &&
       xcodebuild test \
         -workspace Time.xcworkspace \
-        -scheme Shared-Tests-macOS \
-        -sdk macosx10.14 \
-        CODE_SIGN_IDENTITY="" \
-        CODE_SIGNING_REQUIRED=NO \
-        | xcpretty &&
-      xcodebuild test \
-        -workspace Time.xcworkspace \
-        -scheme Shared-Tests-iOS \
-        -destination 'platform=iOS Simulator,name=iPhone XS,OS=12.1' \
+        -scheme "$SCHEME" \
+        -destination "$DESTINATION" \
         CODE_SIGN_IDENTITY="" \
         CODE_SIGNING_REQUIRED=NO \
         | xcpretty

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,13 +33,21 @@ install:
 
 script:
   - |
-    set -o pipefail && xcodebuild test \
-      -workspace Time.xcworkspace \
-      -scheme Shared-Tests \
-      -sdk macosx10.14 \
-      CODE_SIGN_IDENTITY="" \
-      CODE_SIGNING_REQUIRED=NO \
-      | xcpretty
+    set -o pipefail &&
+      xcodebuild test \
+        -workspace Time.xcworkspace \
+        -scheme Shared-Tests-macOS \
+        -sdk macosx10.14 \
+        CODE_SIGN_IDENTITY="" \
+        CODE_SIGNING_REQUIRED=NO \
+        | xcpretty &&
+      xcodebuild test \
+        -workspace Time.xcworkspace \
+        -scheme Shared-Tests-iOS \
+        -destination 'platform=iOS Simulator,name=iPhone XS,OS=12.1' \
+        CODE_SIGN_IDENTITY="" \
+        CODE_SIGNING_REQUIRED=NO \
+        | xcpretty
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/Shared/Helpers/TokenStore.swift
+++ b/Shared/Helpers/TokenStore.swift
@@ -35,7 +35,7 @@ class TokenStore {
             base[kSecAttrAccount as String] = "User \(userID) - \(TokenStore.prefix)"
             base[kSecAttrComment as String] = TokenStore.description
             base[kSecAttrLabel as String] = "Time"
-            base[kSecValueData as String] = data
+            base[kSecValueData as String] = data.data(using: .utf8)
         case .delete:
             break
         }

--- a/Shared/Shared.xcodeproj/project.pbxproj
+++ b/Shared/Shared.xcodeproj/project.pbxproj
@@ -29,6 +29,26 @@
 		D855818421BDEB6400DCB577 /* Time_Shared.h in Headers */ = {isa = PBXBuildFile; fileRef = D855818221BDEB6400DCB577 /* Time_Shared.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D85581AD21BEABC300DCB577 /* EntryType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85581AB21BEABC300DCB577 /* EntryType.swift */; };
 		D85581D821C14D6700DCB577 /* TimeSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D855818021BDEB6400DCB577 /* TimeSDK.framework */; };
+		D85B0A552246F11700835E55 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85B0A542246F11700835E55 /* AppDelegate.swift */; };
+		D85B0A572246F11700835E55 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85B0A562246F11700835E55 /* ViewController.swift */; };
+		D85B0A5A2246F11700835E55 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D85B0A582246F11700835E55 /* Main.storyboard */; };
+		D85B0A5C2246F11900835E55 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D85B0A5B2246F11900835E55 /* Assets.xcassets */; };
+		D85B0A5F2246F11900835E55 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D85B0A5D2246F11900835E55 /* LaunchScreen.storyboard */; };
+		D85B0A6D2246F2ED00835E55 /* Test_0_Setup.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FE621922062549003A095A /* Test_0_Setup.swift */; };
+		D85B0A6E2246F2ED00835E55 /* Test_Token.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8437C5A21F3B04700974B03 /* Test_Token.swift */; };
+		D85B0A6F2246F2ED00835E55 /* Test_Entry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8EA80FC2225776E002686D4 /* Test_Entry.swift */; };
+		D85B0A702246F2ED00835E55 /* Test_API_Categories.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89C7C4A22087B9300B09D73 /* Test_API_Categories.swift */; };
+		D85B0A712246F2ED00835E55 /* Test_API_Entries.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8EA80EF22239130002686D4 /* Test_API_Entries.swift */; };
+		D85B0A722246F2ED00835E55 /* Test_API_Tokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = D811B17821E62B81009F6C8E /* Test_API_Tokens.swift */; };
+		D85B0A732246F2ED00835E55 /* Test_DateHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8EA80F32224E873002686D4 /* Test_DateHelper.swift */; };
+		D85B0A742246F2ED00835E55 /* Test_APIQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = D822E55D22144D710011C09F /* Test_APIQueue.swift */; };
+		D85B0A752246F2ED00835E55 /* Test_API_Accounts.swift in Sources */ = {isa = PBXBuildFile; fileRef = D811B17E21EA451E009F6C8E /* Test_API_Accounts.swift */; };
+		D85B0A762246F2ED00835E55 /* Test_TimeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D822E5622218EAA40011C09F /* Test_TimeError.swift */; };
+		D85B0A772246F2ED00835E55 /* Test_API.swift in Sources */ = {isa = PBXBuildFile; fileRef = D822E5602218E2BC0011C09F /* Test_API.swift */; };
+		D85B0A782246F2ED00835E55 /* Test_TokenStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8437C5F21F4C8C800974B03 /* Test_TokenStore.swift */; };
+		D85B0A792246F2ED00835E55 /* Test_API_Users.swift in Sources */ = {isa = PBXBuildFile; fileRef = D811B17A21E77ECF009F6C8E /* Test_API_Users.swift */; };
+		D85B0A7A2246F2ED00835E55 /* Test_Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = D811B17521E38CD3009F6C8E /* Test_Authentication.swift */; };
+		D85B0A7C2246F2ED00835E55 /* TimeSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D855818021BDEB6400DCB577 /* TimeSDK.framework */; };
 		D89C7C4922087A8700B09D73 /* Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89C7C4822087A8700B09D73 /* Category.swift */; };
 		D89C7C4B22087B9300B09D73 /* Test_API_Categories.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89C7C4A22087B9300B09D73 /* Test_API_Categories.swift */; };
 		D8EA80EA2222501C002686D4 /* Entry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8EA80E92222501C002686D4 /* Entry.swift */; };
@@ -47,6 +67,20 @@
 			proxyType = 1;
 			remoteGlobalIDString = D855817F21BDEB6400DCB577;
 			remoteInfo = Shared;
+		};
+		D85B0A692246F2ED00835E55 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D855815721BDEA4E00DCB577 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D855817F21BDEB6400DCB577;
+			remoteInfo = Shared;
+		};
+		D85B0A6B2246F2ED00835E55 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D855815721BDEA4E00DCB577 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D85B0A512246F11700835E55;
+			remoteInfo = "Time-Shared-iOS-Host";
 		};
 /* End PBXContainerItemProxy section */
 
@@ -74,8 +108,18 @@
 		D855818221BDEB6400DCB577 /* Time_Shared.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Time_Shared.h; sourceTree = "<group>"; };
 		D855818321BDEB6400DCB577 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D85581AB21BEABC300DCB577 /* EntryType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryType.swift; sourceTree = "<group>"; };
-		D85581D321C14D6700DCB577 /* Shared-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Shared-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
-		D85581D721C14D6700DCB577 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D85581D321C14D6700DCB577 /* Shared-Tests-macOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Shared-Tests-macOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		D85581D721C14D6700DCB577 /* Info-macOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-macOS.plist"; sourceTree = "<group>"; };
+		D85B0A522246F11700835E55 /* Time-Shared-iOS-Host.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Time-Shared-iOS-Host.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		D85B0A542246F11700835E55 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		D85B0A562246F11700835E55 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		D85B0A592246F11700835E55 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		D85B0A5B2246F11900835E55 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		D85B0A5E2246F11900835E55 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		D85B0A602246F11900835E55 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D85B0A642246F19F00835E55 /* Time-Shared-iOS-Host.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Time-Shared-iOS-Host.entitlements"; sourceTree = "<group>"; };
+		D85B0A812246F2ED00835E55 /* Shared-Tests-iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Shared-Tests-iOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		D85B0A832246F7C700835E55 /* Info-iOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-iOS.plist"; sourceTree = "<group>"; };
 		D89C7C4822087A8700B09D73 /* Category.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Category.swift; sourceTree = "<group>"; };
 		D89C7C4A22087B9300B09D73 /* Test_API_Categories.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test_API_Categories.swift; sourceTree = "<group>"; };
 		D8EA80E92222501C002686D4 /* Entry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Entry.swift; sourceTree = "<group>"; };
@@ -100,6 +144,21 @@
 			buildActionMask = 2147483647;
 			files = (
 				D85581D821C14D6700DCB577 /* TimeSDK.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D85B0A4F2246F11700835E55 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D85B0A7B2246F2ED00835E55 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D85B0A7C2246F2ED00835E55 /* TimeSDK.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -144,6 +203,7 @@
 				D8437C5C21F4C6AD00974B03 /* Helpers */,
 				D837025521CA802B0095B19F /* Network */,
 				D85581D421C14D6700DCB577 /* Tests */,
+				D85B0A532246F11700835E55 /* iOS-Host */,
 				D855816121BDEA4E00DCB577 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -152,7 +212,9 @@
 			isa = PBXGroup;
 			children = (
 				D855818021BDEB6400DCB577 /* TimeSDK.framework */,
-				D85581D321C14D6700DCB577 /* Shared-Tests.xctest */,
+				D85581D321C14D6700DCB577 /* Shared-Tests-macOS.xctest */,
+				D85B0A522246F11700835E55 /* Time-Shared-iOS-Host.app */,
+				D85B0A812246F2ED00835E55 /* Shared-Tests-iOS.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -183,13 +245,28 @@
 		D85581D421C14D6700DCB577 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				D85581D721C14D6700DCB577 /* Info.plist */,
+				D85B0A832246F7C700835E55 /* Info-iOS.plist */,
+				D85581D721C14D6700DCB577 /* Info-macOS.plist */,
 				D8FE621922062549003A095A /* Test_0_Setup.swift */,
 				D8EA80F62225764D002686D4 /* Network */,
 				D8EA80FB22257749002686D4 /* Models */,
 				D8EA80F822257688002686D4 /* Helpers */,
 			);
 			path = Tests;
+			sourceTree = "<group>";
+		};
+		D85B0A532246F11700835E55 /* iOS-Host */ = {
+			isa = PBXGroup;
+			children = (
+				D85B0A542246F11700835E55 /* AppDelegate.swift */,
+				D85B0A562246F11700835E55 /* ViewController.swift */,
+				D85B0A642246F19F00835E55 /* Time-Shared-iOS-Host.entitlements */,
+				D85B0A582246F11700835E55 /* Main.storyboard */,
+				D85B0A5B2246F11900835E55 /* Assets.xcassets */,
+				D85B0A5D2246F11900835E55 /* LaunchScreen.storyboard */,
+				D85B0A602246F11900835E55 /* Info.plist */,
+			);
+			path = "iOS-Host";
 			sourceTree = "<group>";
 		};
 		D8EA80F62225764D002686D4 /* Network */ = {
@@ -258,9 +335,9 @@
 			productReference = D855818021BDEB6400DCB577 /* TimeSDK.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		D85581D221C14D6700DCB577 /* Shared-Tests */ = {
+		D85581D221C14D6700DCB577 /* Shared-Tests-macOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = D85581DB21C14D6700DCB577 /* Build configuration list for PBXNativeTarget "Shared-Tests" */;
+			buildConfigurationList = D85581DB21C14D6700DCB577 /* Build configuration list for PBXNativeTarget "Shared-Tests-macOS" */;
 			buildPhases = (
 				D85581CF21C14D6700DCB577 /* Sources */,
 				D85581D021C14D6700DCB577 /* Frameworks */,
@@ -271,9 +348,45 @@
 			dependencies = (
 				D85581DA21C14D6700DCB577 /* PBXTargetDependency */,
 			);
-			name = "Shared-Tests";
+			name = "Shared-Tests-macOS";
 			productName = "Time-Shared-Tests";
-			productReference = D85581D321C14D6700DCB577 /* Shared-Tests.xctest */;
+			productReference = D85581D321C14D6700DCB577 /* Shared-Tests-macOS.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		D85B0A512246F11700835E55 /* Time-Shared-iOS-Host */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D85B0A632246F11900835E55 /* Build configuration list for PBXNativeTarget "Time-Shared-iOS-Host" */;
+			buildPhases = (
+				D85B0A4E2246F11700835E55 /* Sources */,
+				D85B0A4F2246F11700835E55 /* Frameworks */,
+				D85B0A502246F11700835E55 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Time-Shared-iOS-Host";
+			productName = "Time-Shared-iOS-Host";
+			productReference = D85B0A522246F11700835E55 /* Time-Shared-iOS-Host.app */;
+			productType = "com.apple.product-type.application";
+		};
+		D85B0A672246F2ED00835E55 /* Shared-Tests-iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D85B0A7E2246F2ED00835E55 /* Build configuration list for PBXNativeTarget "Shared-Tests-iOS" */;
+			buildPhases = (
+				D85B0A6C2246F2ED00835E55 /* Sources */,
+				D85B0A7B2246F2ED00835E55 /* Frameworks */,
+				D85B0A7D2246F2ED00835E55 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				D85B0A682246F2ED00835E55 /* PBXTargetDependency */,
+				D85B0A6A2246F2ED00835E55 /* PBXTargetDependency */,
+			);
+			name = "Shared-Tests-iOS";
+			productName = "Time-Shared-Tests";
+			productReference = D85B0A812246F2ED00835E55 /* Shared-Tests-iOS.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
@@ -293,6 +406,17 @@
 					D85581D221C14D6700DCB577 = {
 						CreatedOnToolsVersion = 10.1;
 					};
+					D85B0A512246F11700835E55 = {
+						CreatedOnToolsVersion = 10.1;
+						SystemCapabilities = {
+							com.apple.Keychain = {
+								enabled = 0;
+							};
+						};
+					};
+					D85B0A672246F2ED00835E55 = {
+						TestTargetID = D85B0A512246F11700835E55;
+					};
 				};
 			};
 			buildConfigurationList = D855815A21BDEA4E00DCB577 /* Build configuration list for PBXProject "Shared" */;
@@ -301,6 +425,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = D855815621BDEA4E00DCB577;
 			productRefGroup = D855816121BDEA4E00DCB577 /* Products */;
@@ -308,7 +433,9 @@
 			projectRoot = "";
 			targets = (
 				D855817F21BDEB6400DCB577 /* Shared */,
-				D85581D221C14D6700DCB577 /* Shared-Tests */,
+				D85581D221C14D6700DCB577 /* Shared-Tests-macOS */,
+				D85B0A672246F2ED00835E55 /* Shared-Tests-iOS */,
+				D85B0A512246F11700835E55 /* Time-Shared-iOS-Host */,
 			);
 		};
 /* End PBXProject section */
@@ -322,6 +449,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		D85581D121C14D6700DCB577 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D85B0A502246F11700835E55 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D85B0A5F2246F11900835E55 /* LaunchScreen.storyboard in Resources */,
+				D85B0A5C2246F11900835E55 /* Assets.xcassets in Resources */,
+				D85B0A5A2246F11700835E55 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D85B0A7D2246F2ED00835E55 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -374,6 +518,36 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		D85B0A4E2246F11700835E55 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D85B0A572246F11700835E55 /* ViewController.swift in Sources */,
+				D85B0A552246F11700835E55 /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D85B0A6C2246F2ED00835E55 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D85B0A6D2246F2ED00835E55 /* Test_0_Setup.swift in Sources */,
+				D85B0A6E2246F2ED00835E55 /* Test_Token.swift in Sources */,
+				D85B0A6F2246F2ED00835E55 /* Test_Entry.swift in Sources */,
+				D85B0A702246F2ED00835E55 /* Test_API_Categories.swift in Sources */,
+				D85B0A712246F2ED00835E55 /* Test_API_Entries.swift in Sources */,
+				D85B0A722246F2ED00835E55 /* Test_API_Tokens.swift in Sources */,
+				D85B0A732246F2ED00835E55 /* Test_DateHelper.swift in Sources */,
+				D85B0A742246F2ED00835E55 /* Test_APIQueue.swift in Sources */,
+				D85B0A752246F2ED00835E55 /* Test_API_Accounts.swift in Sources */,
+				D85B0A762246F2ED00835E55 /* Test_TimeError.swift in Sources */,
+				D85B0A772246F2ED00835E55 /* Test_API.swift in Sources */,
+				D85B0A782246F2ED00835E55 /* Test_TokenStore.swift in Sources */,
+				D85B0A792246F2ED00835E55 /* Test_API_Users.swift in Sources */,
+				D85B0A7A2246F2ED00835E55 /* Test_Authentication.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -382,7 +556,36 @@
 			target = D855817F21BDEB6400DCB577 /* Shared */;
 			targetProxy = D85581D921C14D6700DCB577 /* PBXContainerItemProxy */;
 		};
+		D85B0A682246F2ED00835E55 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = D855817F21BDEB6400DCB577 /* Shared */;
+			targetProxy = D85B0A692246F2ED00835E55 /* PBXContainerItemProxy */;
+		};
+		D85B0A6A2246F2ED00835E55 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = D85B0A512246F11700835E55 /* Time-Shared-iOS-Host */;
+			targetProxy = D85B0A6B2246F2ED00835E55 /* PBXContainerItemProxy */;
+		};
 /* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		D85B0A582246F11700835E55 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				D85B0A592246F11700835E55 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		D85B0A5D2246F11900835E55 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				D85B0A5E2246F11900835E55 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
 		D855816621BDEA4E00DCB577 /* Debug */ = {
@@ -583,7 +786,7 @@
 					"$(SDKROOT)",
 					"$(inherited)",
 				);
-				INFOPLIST_FILE = Tests/Info.plist;
+				INFOPLIST_FILE = "Tests/Info-macOS.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -595,7 +798,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.nathantornquist.Time-Shared-Tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos";
+				SUPPORTED_PLATFORMS = macosx;
 				SWIFT_VERSION = 4.2;
 				VALID_ARCHS = "i386 x86_64 armv7s armv7 arm64e arm64";
 			};
@@ -612,7 +815,7 @@
 					"$(SDKROOT)",
 					"$(inherited)",
 				);
-				INFOPLIST_FILE = Tests/Info.plist;
+				INFOPLIST_FILE = "Tests/Info-macOS.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -624,8 +827,104 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.nathantornquist.Time-Shared-Tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos";
+				SUPPORTED_PLATFORMS = macosx;
 				SWIFT_VERSION = 4.2;
+				VALID_ARCHS = "i386 x86_64 armv7s armv7 arm64e arm64";
+			};
+			name = Release;
+		};
+		D85B0A612246F11900835E55 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 99AECXNBFU;
+				INFOPLIST_FILE = "iOS-Host/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.nathantornquist.Time-Shared-iOS-Host";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.2;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		D85B0A622246F11900835E55 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 99AECXNBFU;
+				INFOPLIST_FILE = "iOS-Host/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.nathantornquist.Time-Shared-iOS-Host";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.2;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		D85B0A7F2246F2ED00835E55 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = 99AECXNBFU;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = "Tests/Info-macOS.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.nathantornquist.Time-Shared-Tests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
+				SWIFT_VERSION = 4.2;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Time-Shared-iOS-Host.app/Time-Shared-iOS-Host";
+				VALID_ARCHS = "i386 x86_64 armv7s armv7 arm64e arm64";
+			};
+			name = Debug;
+		};
+		D85B0A802246F2ED00835E55 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = 99AECXNBFU;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = "Tests/Info-macOS.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.nathantornquist.Time-Shared-Tests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
+				SWIFT_VERSION = 4.2;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Time-Shared-iOS-Host.app/Time-Shared-iOS-Host";
 				VALID_ARCHS = "i386 x86_64 armv7s armv7 arm64e arm64";
 			};
 			name = Release;
@@ -651,11 +950,29 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		D85581DB21C14D6700DCB577 /* Build configuration list for PBXNativeTarget "Shared-Tests" */ = {
+		D85581DB21C14D6700DCB577 /* Build configuration list for PBXNativeTarget "Shared-Tests-macOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				D85581DC21C14D6700DCB577 /* Debug */,
 				D85581DD21C14D6700DCB577 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D85B0A632246F11900835E55 /* Build configuration list for PBXNativeTarget "Time-Shared-iOS-Host" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D85B0A612246F11900835E55 /* Debug */,
+				D85B0A622246F11900835E55 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D85B0A7E2246F2ED00835E55 /* Build configuration list for PBXNativeTarget "Shared-Tests-iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D85B0A7F2246F2ED00835E55 /* Debug */,
+				D85B0A802246F2ED00835E55 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Shared/Shared.xcodeproj/xcshareddata/xcschemes/Shared-Tests-iOS-Host.xcscheme
+++ b/Shared/Shared.xcodeproj/xcshareddata/xcschemes/Shared-Tests-iOS-Host.xcscheme
@@ -9,14 +9,14 @@
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
-            buildForProfiling = "NO"
-            buildForArchiving = "NO"
-            buildForAnalyzing = "NO">
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "D85581D221C14D6700DCB577"
-               BuildableName = "Shared-Tests.xctest"
-               BlueprintName = "Shared-Tests"
+               BlueprintIdentifier = "D85B0A512246F11700835E55"
+               BuildableName = "Time-Shared-iOS-Host.app"
+               BlueprintName = "Time-Shared-iOS-Host"
                ReferencedContainer = "container:Shared.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -26,30 +26,18 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      codeCoverageEnabled = "YES"
-      onlyGenerateCoverageForSpecifiedTargets = "YES"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <CodeCoverageTargets>
+      <Testables>
+      </Testables>
+      <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "D855817F21BDEB6400DCB577"
-            BuildableName = "TimeSDK.framework"
-            BlueprintName = "Shared"
+            BlueprintIdentifier = "D85B0A512246F11700835E55"
+            BuildableName = "Time-Shared-iOS-Host.app"
+            BlueprintName = "Time-Shared-iOS-Host"
             ReferencedContainer = "container:Shared.xcodeproj">
          </BuildableReference>
-      </CodeCoverageTargets>
-      <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "D85581D221C14D6700DCB577"
-               BuildableName = "Shared-Tests.xctest"
-               BlueprintName = "Shared-Tests"
-               ReferencedContainer = "container:Shared.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-      </Testables>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>
@@ -63,15 +51,16 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <MacroExpansion>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "D85581D221C14D6700DCB577"
-            BuildableName = "Shared-Tests.xctest"
-            BlueprintName = "Shared-Tests"
+            BlueprintIdentifier = "D85B0A512246F11700835E55"
+            BuildableName = "Time-Shared-iOS-Host.app"
+            BlueprintName = "Time-Shared-iOS-Host"
             ReferencedContainer = "container:Shared.xcodeproj">
          </BuildableReference>
-      </MacroExpansion>
+      </BuildableProductRunnable>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
@@ -81,15 +70,16 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "D85581D221C14D6700DCB577"
-            BuildableName = "Shared-Tests.xctest"
-            BlueprintName = "Shared-Tests"
+            BlueprintIdentifier = "D85B0A512246F11700835E55"
+            BuildableName = "Time-Shared-iOS-Host.app"
+            BlueprintName = "Time-Shared-iOS-Host"
             ReferencedContainer = "container:Shared.xcodeproj">
          </BuildableReference>
-      </MacroExpansion>
+      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Shared/Shared.xcodeproj/xcshareddata/xcschemes/Shared-Tests-iOS.xcscheme
+++ b/Shared/Shared.xcodeproj/xcshareddata/xcschemes/Shared-Tests-iOS.xcscheme
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D85B0A672246F2ED00835E55"
+               BuildableName = "Shared-Tests-iOS.xctest"
+               BlueprintName = "Shared-Tests-iOS"
+               ReferencedContainer = "container:Shared.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D85B0A512246F11700835E55"
+               BuildableName = "Time-Shared-iOS-Host.app"
+               BlueprintName = "Time-Shared-iOS-Host"
+               ReferencedContainer = "container:Shared.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D85B0A672246F2ED00835E55"
+               BuildableName = "Shared-Tests-iOS.xctest"
+               BlueprintName = "Shared-Tests-iOS"
+               ReferencedContainer = "container:Shared.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D85B0A672246F2ED00835E55"
+            BuildableName = "Shared-Tests-iOS.xctest"
+            BlueprintName = "Shared-Tests-iOS"
+            ReferencedContainer = "container:Shared.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D85B0A672246F2ED00835E55"
+            BuildableName = "Shared-Tests-iOS.xctest"
+            BlueprintName = "Shared-Tests-iOS"
+            ReferencedContainer = "container:Shared.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Shared/Shared.xcodeproj/xcshareddata/xcschemes/Shared-Tests-macOS.xcscheme
+++ b/Shared/Shared.xcodeproj/xcshareddata/xcschemes/Shared-Tests-macOS.xcscheme
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D85581D221C14D6700DCB577"
+               BuildableName = "Shared-Tests-macOS.xctest"
+               BlueprintName = "Shared-Tests-macOS"
+               ReferencedContainer = "container:Shared.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D855817F21BDEB6400DCB577"
+            BuildableName = "TimeSDK.framework"
+            BlueprintName = "Shared"
+            ReferencedContainer = "container:Shared.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D85581D221C14D6700DCB577"
+               BuildableName = "Shared-Tests-macOS.xctest"
+               BlueprintName = "Shared-Tests-macOS"
+               ReferencedContainer = "container:Shared.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D85581D221C14D6700DCB577"
+            BuildableName = "Shared-Tests-macOS.xctest"
+            BlueprintName = "Shared-Tests-macOS"
+            ReferencedContainer = "container:Shared.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D85581D221C14D6700DCB577"
+            BuildableName = "Shared-Tests-macOS.xctest"
+            BlueprintName = "Shared-Tests-macOS"
+            ReferencedContainer = "container:Shared.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Shared/Tests/Info-iOS.plist
+++ b/Shared/Tests/Info-iOS.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>LSApplicationCategoryType</key>
+	<string></string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>

--- a/Shared/Tests/Info-macOS.plist
+++ b/Shared/Tests/Info-macOS.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>LSApplicationCategoryType</key>
+	<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/Shared/Tests/Test_APIQueue.swift
+++ b/Shared/Tests/Test_APIQueue.swift
@@ -14,8 +14,6 @@ class Test_APIQueue: XCTestCase {
     var queue: APIQueue!
     
     override func setUp() {
-        self.continueAfterFailure = false
-        
         queue = APIQueue()
     }
     
@@ -190,8 +188,6 @@ class Test_APIQueue: XCTestCase {
     }
     
     func test_retryAllFailedModelsMixedClasses() {
-        self.continueAfterFailure = false
-        
         // Create a bunch of requests
         var expectations: [String: XCTestExpectation] = [:]
         
@@ -237,8 +233,6 @@ class Test_APIQueue: XCTestCase {
     }
     
     func test_retryAllFailedModelsMixedTypes() {
-        self.continueAfterFailure = false
-        
         // Build tests
         let expectationA = self.expectation(description: "a")
         let expectationB = self.expectation(description: "b")
@@ -280,8 +274,6 @@ class Test_APIQueue: XCTestCase {
     }
     
     func test_failAllFailedModels() {
-        self.continueAfterFailure = false
-        
         let failureError = TimeError.authenticationFailure("System failure")
     
         // Build tests

--- a/Shared/Tests/Test_API_Accounts.swift
+++ b/Shared/Tests/Test_API_Accounts.swift
@@ -14,14 +14,19 @@ class Test_API_Accounts: XCTestCase {
     static var accountID: Int? = nil
     
     override func setUp() {
-        self.continueAfterFailure = false
-        
+        var succeeded = false
         let getTokenExpectation = self.expectation(description: "getToken")
         API.shared.getToken(withUsername: "test@test.com", andPassword: "defaultPassword") { (token, error) in
             XCTAssertNotNil(token)
+            succeeded = token != nil
             getTokenExpectation.fulfill()
         }
         waitForExpectations(timeout: 5, handler: nil)
+        
+        guard succeeded else {
+            XCTFail("Token not found.")
+            return
+        }
     }
     
     override func tearDown() { }

--- a/Shared/Tests/Test_API_Categories.swift
+++ b/Shared/Tests/Test_API_Categories.swift
@@ -61,8 +61,6 @@ class Test_API_Categories: XCTestCase {
     }
     
     func test_0_startsWithNoAccountsAndNoCategories() {
-        self.continueAfterFailure = false
-        
         let categoriesExpectation = self.expectation(description: "getCategories")
         api.getCategories { (categories, error) in
             XCTAssertNil(error)
@@ -83,8 +81,6 @@ class Test_API_Categories: XCTestCase {
     }
     
     func test_1_createsARootCategoryWithEachNewAccount() {
-        self.continueAfterFailure = false
-        
         var newAccount: Account?
         let accountExpectation = self.expectation(description: "createAccount")
         api.createAccount { (account, error) in
@@ -98,6 +94,10 @@ class Test_API_Categories: XCTestCase {
             }
         }
         waitForExpectations(timeout: 5, handler: nil)
+        guard newAccount != nil else {
+            XCTFail("New acocunt not found. Required to continue.")
+            return
+        }
         
         let categoriesExpectation = self.expectation(description: "getCategories")
         api.getCategories { (categories, error) in
@@ -120,8 +120,6 @@ class Test_API_Categories: XCTestCase {
     }
     
     func test_2_creatingAChildCategory() {
-        self.continueAfterFailure = false
-        
         guard self.categories.count == 1 else {
             XCTFail("Test requires a single category to exist")
             return
@@ -180,8 +178,6 @@ class Test_API_Categories: XCTestCase {
     }
     
     func test_3_createASiblingCategory() {
-        self.continueAfterFailure = false
-        
         guard self.categories.count == 2 else {
             XCTFail("Test requires two categories to exist")
             return
@@ -224,8 +220,6 @@ class Test_API_Categories: XCTestCase {
     }
     
     func test_4_allowsCategoriesToBeMoved() {
-        self.continueAfterFailure = false
-        
         guard let root = self.categories.first(where: { $0.name == "root" }),
             let categoryA = self.categories.first(where: { $0.name == "A" }),
             let categoryB = self.categories.first(where: { $0.name == "B" }) else {
@@ -253,8 +247,6 @@ class Test_API_Categories: XCTestCase {
     }
     
     func test_5_allowsMovingCategoriesBetweenAccounts() {
-        self.continueAfterFailure = false
-        
         // Create a second account
         let accountExpectation = self.expectation(description: "createAccount")
         api.createAccount { (account, error) in
@@ -333,8 +325,6 @@ class Test_API_Categories: XCTestCase {
     }
     
     func test_6_rejectsMovingCategoriesWithMismatchedParentAndAccountIDs() {
-        self.continueAfterFailure = false
-        
         guard
             let firstRoot = self.categories.first(where: { $0.parentID == nil && $0.accountID == self.accounts[0].id }),
             let secondRoot = self.categories.first(where: { $0.parentID == nil && $0.accountID == self.accounts[1].id }),
@@ -367,8 +357,6 @@ class Test_API_Categories: XCTestCase {
     }
     
     func test_7_allowsRenamingCategories() {
-        self.continueAfterFailure = false
-        
         guard let categoryB = self.categories.first(where: { $0.name == "B" }) else {
             XCTFail("Missing required root nodes")
             return
@@ -392,8 +380,6 @@ class Test_API_Categories: XCTestCase {
     }
     
     func test_8_deletingCategories() {
-        self.continueAfterFailure = false
-        
         guard
             let secondRoot = self.categories.first(where: { $0.parentID == nil && $0.accountID == self.accounts[1].id }),
             let categoryA = self.categories.first(where: { $0.name == "A" }),

--- a/Shared/Tests/Test_API_Tokens.swift
+++ b/Shared/Tests/Test_API_Tokens.swift
@@ -46,8 +46,6 @@ class Test_API_Tokens: XCTestCase {
     }
     
     func test_refreshToken_validRefresh() {
-        self.continueAfterFailure = false
-        
         var startingToken: Token? = nil
         let getExpectation = self.expectation(description: "getToken")
         API.shared.getToken(withUsername: "test@test.com", andPassword: "defaultPassword") { (authToken, error) in
@@ -57,13 +55,14 @@ class Test_API_Tokens: XCTestCase {
             getExpectation.fulfill()
         }
         waitForExpectations(timeout: 5, handler: nil)
+        guard startingToken != nil else { return }
         
         let refreshExpectation = self.expectation(description: "refreshToken")
         API.shared.refreshToken() { (refreshedToken, error) in
             XCTAssertNotNil(refreshedToken)
             XCTAssertNil(error)
             
-            XCTAssertNotEqual(startingToken!.token, refreshedToken!.token)
+            XCTAssertNotEqual(startingToken!.token, refreshedToken?.token ?? startingToken!.token)
             refreshExpectation.fulfill()
         }
         waitForExpectations(timeout: 5, handler: nil)

--- a/Shared/Tests/Test_Authentication.swift
+++ b/Shared/Tests/Test_Authentication.swift
@@ -30,13 +30,15 @@ class Test_Authentication: XCTestCase {
     }
     
     func test_1_initializeWithNoTokenReturnsTokenNotFound() {
-        self.continueAfterFailure = false
-        
         let expectation = self.expectation(description: "authentication")
         
         self.time.initialize { (error) in
             XCTAssertNotNil(error)
-            XCTAssertEqual(error as! TimeError, TimeError.tokenNotFound())
+            if let timeError = error as? TimeError {
+                XCTAssertEqual(timeError, TimeError.tokenNotFound())
+            } else {
+                XCTFail("Unknown error message returned")
+            }
             
             expectation.fulfill()
         }
@@ -45,8 +47,6 @@ class Test_Authentication: XCTestCase {
     }
     
     func test_2_authenticateSetsToken() {
-        self.continueAfterFailure = false
-        
         let username = "test@test.com"
         let password = "defaultPassword"
         
@@ -105,8 +105,6 @@ class Test_Authentication: XCTestCase {
     }
     
     func test_6_initializeWithAnExpiredTokenRefreshes() {
-        self.continueAfterFailure = false
-        
         guard let startingToken = TokenStore.getToken(withTag: self.tokenTag) else {
             XCTAssertTrue(false, "Test conditions not met")
             return
@@ -119,7 +117,10 @@ class Test_Authentication: XCTestCase {
             refresh: startingToken.refresh
         )
         let storedExpiredToken = TokenStore.storeToken(newToken, withTag: self.tokenTag)
-        XCTAssertTrue(storedExpiredToken)
+        guard storedExpiredToken else {
+            XCTFail("Token could not be stored")
+            return
+        }
         
         // Clear API token for true refresh
         self.api.token = nil
@@ -139,8 +140,6 @@ class Test_Authentication: XCTestCase {
     }
     
     func test_7_initializeWithAnInvalidRefreshTokenRejects() {
-        self.continueAfterFailure = false
-        
         guard let startingToken = TokenStore.getToken(withTag: self.tokenTag) else {
             XCTAssertTrue(false, "Test conditions not met")
             return
@@ -153,7 +152,10 @@ class Test_Authentication: XCTestCase {
             refresh: "This is not a real token"
         )
         let storedExpiredToken = TokenStore.storeToken(newToken, withTag: self.tokenTag)
-        XCTAssertTrue(storedExpiredToken)
+        guard storedExpiredToken else {
+            XCTFail("Token could not be stored")
+            return
+        }
         
         // Clear API token for true refresh
         self.api.token = nil

--- a/Shared/Tests/Test_DateHelper.swift
+++ b/Shared/Tests/Test_DateHelper.swift
@@ -72,16 +72,16 @@ class Test_DateHelper: XCTestCase {
     }
     
     func test_dateFromStringWithoutMilliseconds() {
-        self.continueAfterFailure = false
         let dateString = "2019-02-25T03:09:53Z"
-        let date = DateHelper.dateFrom(isoString: dateString)
+        guard let date = DateHelper.dateFrom(isoString: dateString) else {
+            XCTFail("Parsed date not found.")
+            return
+        }
         
-        XCTAssertNotNil(date)
-
         var calendar = Calendar.current
         calendar.timeZone = TimeZone(identifier: "UTC")!
         
-        let dateComponents = calendar.dateComponents([.year, .month, .day, .hour, .minute, .second, .nanosecond], from: date!)
+        let dateComponents = calendar.dateComponents([.year, .month, .day, .hour, .minute, .second, .nanosecond], from: date)
         XCTAssertEqual(dateComponents.year, 2019)
         XCTAssertEqual(dateComponents.month, 2)
         XCTAssertEqual(dateComponents.day, 25)

--- a/Shared/Tests/Test_Entry.swift
+++ b/Shared/Tests/Test_Entry.swift
@@ -12,8 +12,6 @@ import XCTest
 class Test_Entry: XCTestCase {
     
     func test_decodable() {
-        self.continueAfterFailure = false
-        
         let startString = "2019-02-25T03:09:53.394Z"
         let endString = "2019-02-27T02:08:53.394Z"
         let entryDictionary: [String: Any] = [
@@ -23,47 +21,51 @@ class Test_Entry: XCTestCase {
             "started_at": startString,
             "ended_at": endString
         ]
-        let entryData = try? JSONSerialization.data(
+        guard let entryData = try? JSONSerialization.data(
             withJSONObject: entryDictionary,
             options: .prettyPrinted
-        )
-        XCTAssertNotNil(entryData)
+            ) else {
+            XCTFail("EntryData cannot be nil")
+               return
+        }
         
-        let entry = try? JSONDecoder().decode(Entry.self, from: entryData!)
-        XCTAssertNotNil(entry)
+        guard let entry = try? JSONDecoder().decode(Entry.self, from: entryData) else {
+            XCTFail("Entry cannot be nil")
+            return
+        }
         
-        XCTAssertEqual(entry!.id, 15)
-        XCTAssertEqual(entry!.type, EntryType.range)
-        XCTAssertEqual(entry!.categoryID, 16)
+        XCTAssertEqual(entry.id, 15)
+        XCTAssertEqual(entry.type, EntryType.range)
+        XCTAssertEqual(entry.categoryID, 16)
         XCTAssertEqual(
-            entry!.startedAt.timeIntervalSinceReferenceDate,
+            entry.startedAt.timeIntervalSinceReferenceDate,
             DateHelper.dateFrom(isoString: startString)?.timeIntervalSinceReferenceDate ?? -200,
             accuracy: 1.0
         )
         XCTAssertEqual(
-            entry!.endedAt?.timeIntervalSinceReferenceDate ?? -100,
+            entry.endedAt?.timeIntervalSinceReferenceDate ?? -100,
             DateHelper.dateFrom(isoString: endString)?.timeIntervalSinceReferenceDate ?? -200,
             accuracy: 1.0
         )
     }
     
     func test_decodableError() {
-        self.continueAfterFailure = false
-
         let entryDictionary: [String: Any] = [
             "id": 15,
             "type": "event",
             "category_id": 16,
             "started_at": "March 3rd, 2019 12:01pm"
         ]
-        let entryData = try? JSONSerialization.data(
+        guard let entryData = try? JSONSerialization.data(
             withJSONObject: entryDictionary,
             options: .prettyPrinted
-        )
-        XCTAssertNotNil(entryData)
+            ) else {
+            XCTFail("Entry data could not be serialized")
+            return
+        }
         
         do {
-            _ = try JSONDecoder().decode(Entry.self, from: entryData!)
+            _ = try JSONDecoder().decode(Entry.self, from: entryData)
             XCTFail("Expected entry to throw")
         } catch {
             XCTAssertEqual(error as? TimeError, TimeError.unableToDecodeResponse())
@@ -71,8 +73,6 @@ class Test_Entry: XCTestCase {
     }
     
     func test_encodable() {
-        self.continueAfterFailure = false
-        
         let id = 16
         let type = EntryType.event
         let categoryID = 17
@@ -80,17 +80,22 @@ class Test_Entry: XCTestCase {
         
         let entry = Entry(id: id, type: type, categoryID: categoryID, startedAt: startedAt, endedAt: nil)
         
-        let encodedEntry = try? JSONEncoder().encode(entry)
-        XCTAssertNotNil(encodedEntry)
-        let decodedEntry = try? JSONDecoder().decode(Entry.self, from: encodedEntry!)
-        XCTAssertNotNil(decodedEntry)
+        guard let encodedEntry = try? JSONEncoder().encode(entry) else {
+            XCTFail("Entry could not be encoded")
+            return
+        }
         
-        XCTAssertEqual(entry.id, decodedEntry!.id)
-        XCTAssertEqual(entry.type, decodedEntry!.type)
-        XCTAssertEqual(entry.categoryID, decodedEntry!.categoryID)
+        guard let decodedEntry = try? JSONDecoder().decode(Entry.self, from: encodedEntry) else {
+            XCTFail("Entry could not be decoded")
+            return
+        }
+        
+        XCTAssertEqual(entry.id, decodedEntry.id)
+        XCTAssertEqual(entry.type, decodedEntry.type)
+        XCTAssertEqual(entry.categoryID, decodedEntry.categoryID)
         XCTAssertEqual(
             entry.startedAt.timeIntervalSinceReferenceDate,
-            decodedEntry!.startedAt.timeIntervalSinceReferenceDate,
+            decodedEntry.startedAt.timeIntervalSinceReferenceDate,
             accuracy: 0.001
         )
     }

--- a/Shared/Tests/Test_Token.swift
+++ b/Shared/Tests/Test_Token.swift
@@ -15,8 +15,6 @@ class Test_Token: XCTestCase {
     override func tearDown() { }
     
     func test_decodable() {
-        self.continueAfterFailure = false
-        
         // Default date parsing is in seconds. API returns MS.
         // creation: Saturday, January 19, 2019 1:00:35.987 PM GMT-06:00
         // expiration: Saturday, January 19, 2019 5:00:35.987 PM GMT-06:00
@@ -27,33 +25,34 @@ class Test_Token: XCTestCase {
             "token": "6coYVjJb168677c74131c76yC7yDabbIB9QKbk",
             "refresh": "e4uL1c2tNlEkAlab168677c74131c76Dg2yznuTZ24n3xj6Y"
         ]
-        let tokenData = try? JSONSerialization.data(
+        guard let tokenData = try? JSONSerialization.data(
             withJSONObject: tokenDictionary,
             options: .prettyPrinted
-        )
-        XCTAssertNotNil(tokenData)
+            ) else {
+            XCTFail("Token data not serialized.")
+            return
+        }
 
-        let token = try? JSONDecoder().decode(Token.self, from: tokenData!)
-        XCTAssertNotNil(token)
+        guard let token = try? JSONDecoder().decode(Token.self, from: tokenData) else {
+            XCTFail("Token failed to decode.")
+            return
+        }
         
-        XCTAssertEqual(token!.userID, tokenDictionary["user_id"] as! Int)
-        print(token!.creation)
+        XCTAssertEqual(token.userID, tokenDictionary["user_id"] as! Int)
         
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy/MM/dd HH:mm:ss.SSS Z"
         // Generate dates in CST as example. Will compare in GMT
         let expectedCreationTime = formatter.date(from: "2019/01/19 13:00:35.987 -0600")!
         let expectedRefreshTime = formatter.date(from: "2019/01/19 17:00:35.987 -0600")!
-        XCTAssertEqual(token!.creation.timeIntervalSinceReferenceDate, expectedCreationTime.timeIntervalSinceReferenceDate, accuracy: 0.001)
-        XCTAssertEqual(token!.expiration.timeIntervalSinceReferenceDate, expectedRefreshTime.timeIntervalSinceReferenceDate, accuracy: 0.001)
+        XCTAssertEqual(token.creation.timeIntervalSinceReferenceDate, expectedCreationTime.timeIntervalSinceReferenceDate, accuracy: 0.001)
+        XCTAssertEqual(token.expiration.timeIntervalSinceReferenceDate, expectedRefreshTime.timeIntervalSinceReferenceDate, accuracy: 0.001)
 
-        XCTAssertEqual(token!.token, tokenDictionary["token"] as! String)
-        XCTAssertEqual(token!.refresh, tokenDictionary["refresh"] as! String)
+        XCTAssertEqual(token.token, tokenDictionary["token"] as! String)
+        XCTAssertEqual(token.refresh, tokenDictionary["refresh"] as! String)
     }
     
     func test_encodable() {
-        self.continueAfterFailure = false
-        
         let userID = 1234
         let creation = Date()
         let expiration = Date()
@@ -62,15 +61,19 @@ class Test_Token: XCTestCase {
         
         let token = Token(userID: userID, creation: creation, expiration: expiration, token: tokenKey, refresh: refreshKey)
         
-        let encodedToken = try? JSONEncoder().encode(token)
-        XCTAssertNotNil(encodedToken)
-        let decodedToken = try? JSONDecoder().decode(Token.self, from: encodedToken!)
-        XCTAssertNotNil(decodedToken)
+        guard let encodedToken = try? JSONEncoder().encode(token) else {
+            XCTFail("Token failed to encode.")
+            return
+        }
+        guard let decodedToken = try? JSONDecoder().decode(Token.self, from: encodedToken) else {
+            XCTFail("Token failed to decode.")
+            return
+        }
         
-        XCTAssertEqual(token.userID, decodedToken!.userID)
-        XCTAssertEqual(token.creation.timeIntervalSinceReferenceDate, decodedToken!.creation.timeIntervalSinceReferenceDate, accuracy: 0.001)
-        XCTAssertEqual(token.expiration.timeIntervalSinceReferenceDate, decodedToken!.expiration.timeIntervalSinceReferenceDate, accuracy: 0.001)
-        XCTAssertEqual(token.token, decodedToken!.token)
-        XCTAssertEqual(token.refresh, decodedToken!.refresh)
+        XCTAssertEqual(token.userID, decodedToken.userID)
+        XCTAssertEqual(token.creation.timeIntervalSinceReferenceDate, decodedToken.creation.timeIntervalSinceReferenceDate, accuracy: 0.001)
+        XCTAssertEqual(token.expiration.timeIntervalSinceReferenceDate, decodedToken.expiration.timeIntervalSinceReferenceDate, accuracy: 0.001)
+        XCTAssertEqual(token.token, decodedToken.token)
+        XCTAssertEqual(token.refresh, decodedToken.refresh)
     }
 }

--- a/Shared/Tests/Test_TokenStore.swift
+++ b/Shared/Tests/Test_TokenStore.swift
@@ -37,16 +37,16 @@ class Test_TokenStore: XCTestCase {
     }
     
     func test_3_allowsRetrievalOfAToken() {
-        self.continueAfterFailure = false
+        guard let token = TokenStore.getToken(withTag: "test-token") else {
+            XCTFail("Token not found.")
+            return
+        }
         
-        let token = TokenStore.getToken(withTag: "test-token")
-        XCTAssertNotNil(token)
-        
-        XCTAssertEqual(token!.userID, 1234)
-        XCTAssertEqual(token!.creation.timeIntervalSinceReferenceDate, 0, accuracy: 0.01)
-        XCTAssertEqual(token!.expiration.timeIntervalSinceReferenceDate, 10000, accuracy: 0.01)
-        XCTAssertEqual(token!.token, "myToken")
-        XCTAssertEqual(token!.refresh, "myRefreshToken")
+        XCTAssertEqual(token.userID, 1234)
+        XCTAssertEqual(token.creation.timeIntervalSinceReferenceDate, 0, accuracy: 0.01)
+        XCTAssertEqual(token.expiration.timeIntervalSinceReferenceDate, 10000, accuracy: 0.01)
+        XCTAssertEqual(token.token, "myToken")
+        XCTAssertEqual(token.refresh, "myRefreshToken")
     }
     
     func test_4_allowsANewTokenToBeStored() {
@@ -63,16 +63,16 @@ class Test_TokenStore: XCTestCase {
     }
     
     func test_5_allowsRetrievalOfTheMostRecentToken() {
-        self.continueAfterFailure = false
+        guard let token = TokenStore.getToken(withTag: "test-token") else {
+            XCTFail("Token not found.")
+            return
+        }
         
-        let token = TokenStore.getToken(withTag: "test-token")
-        XCTAssertNotNil(token)
-        
-        XCTAssertEqual(token!.userID, 1235)
-        XCTAssertEqual(token!.creation.timeIntervalSinceReferenceDate, 10, accuracy: 0.01)
-        XCTAssertEqual(token!.expiration.timeIntervalSinceReferenceDate, 20000, accuracy: 0.01)
-        XCTAssertEqual(token!.token, "myNewToken")
-        XCTAssertEqual(token!.refresh, "myNewRefreshToken")
+        XCTAssertEqual(token.userID, 1235)
+        XCTAssertEqual(token.creation.timeIntervalSinceReferenceDate, 10, accuracy: 0.01)
+        XCTAssertEqual(token.expiration.timeIntervalSinceReferenceDate, 20000, accuracy: 0.01)
+        XCTAssertEqual(token.token, "myNewToken")
+        XCTAssertEqual(token.refresh, "myNewRefreshToken")
     }
     
     func test_6_allowsDeletion() {

--- a/Shared/iOS-Host/AppDelegate.swift
+++ b/Shared/iOS-Host/AppDelegate.swift
@@ -1,0 +1,46 @@
+//
+//  AppDelegate.swift
+//  Time-Shared-iOS-Host
+//
+//  Created by Nathan Tornquist on 3/23/19.
+//  Copyright © 2019 nathantornquist. All rights reserved.
+//
+
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    var window: UIWindow?
+
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    func applicationWillResignActive(_ application: UIApplication) {
+        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+        // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks. Games should use this method to pause the game.
+    }
+
+    func applicationDidEnterBackground(_ application: UIApplication) {
+        // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
+        // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+    }
+
+    func applicationWillEnterForeground(_ application: UIApplication) {
+        // Called as part of the transition from the background to the active state; here you can undo many of the changes made on entering the background.
+    }
+
+    func applicationDidBecomeActive(_ application: UIApplication) {
+        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+    }
+
+    func applicationWillTerminate(_ application: UIApplication) {
+        // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+    }
+
+
+}
+

--- a/Shared/iOS-Host/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Shared/iOS-Host/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "83.5x83.5",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Shared/iOS-Host/Assets.xcassets/Contents.json
+++ b/Shared/iOS-Host/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Shared/iOS-Host/Base.lproj/LaunchScreen.storyboard
+++ b/Shared/iOS-Host/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/Shared/iOS-Host/Base.lproj/Main.storyboard
+++ b/Shared/iOS-Host/Base.lproj/Main.storyboard
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/Shared/iOS-Host/Info.plist
+++ b/Shared/iOS-Host/Info.plist
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
+	</dict>
+</dict>
+</plist>

--- a/Shared/iOS-Host/Time-Shared-iOS-Host.entitlements
+++ b/Shared/iOS-Host/Time-Shared-iOS-Host.entitlements
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/Shared/iOS-Host/ViewController.swift
+++ b/Shared/iOS-Host/ViewController.swift
@@ -1,0 +1,20 @@
+//
+//  ViewController.swift
+//  Time-Shared-iOS-Host
+//
+//  Created by Nathan Tornquist on 3/23/19.
+//  Copyright © 2019 nathantornquist. All rights reserved.
+//
+
+import UIKit
+
+class ViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Do any additional setup after loading the view, typically from a nib.
+    }
+
+
+}
+


### PR DESCRIPTION
# 💚 Summary

## Problem

While working on the app-authentication branch I noticed that the keychain login was not working as-expected for the iOS app. Authentication worked, but the tokens were not being stored properly and it was requiring a fresh login every time.

## Solution

* Add iOS Test Host to allow proper entitlement generation (Cannot test keychain without a test host)
* Repair broken keychain login --> iOS requires data to be passed as a 'Data' object. I was passing the data as a `String`
* Add matrix testing to run all tests against macOS and iOS
* Remove all `continueAfterFailure` calls. This is not directly necessary, but based on the code seen here: https://github.com/apple/swift-corelibs-xctest/blob/master/Sources/XCTest/Public/XCTestCase.swift#L173 I wanted to make sure that my tests had no reliance on what test harnesses were implemented in Swift. I believe my use of `continueAfterFailure` was working properly (would have seen more segfaults locally otherwise), but I still want to make sure.