### PR TITLE
Timezones

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
 
 install:
   # Clone API and merge current source with cached node_modules.
-  - git clone --depth 1 --single-branch --branch timezones git://github.com/Tornquist/Time-API.git api
+  - git clone --depth 1 git://github.com/Tornquist/Time-API.git api
   - cp -a api/. Time-API/
   - rm -rf api
   # Install API dependencies. Create and migrate database.

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
 
 install:
   # Clone API and merge current source with cached node_modules.
-  - git clone --depth 1 git://github.com/Tornquist/Time-API.git api
+  - git clone --depth 1 --single-branch --branch timezones git://github.com/Tornquist/Time-API.git api
   - cp -a api/. Time-API/
   - rm -rf api
   # Install API dependencies. Create and migrate database.

--- a/Shared/Interface/Store.swift
+++ b/Shared/Interface/Store.swift
@@ -310,11 +310,12 @@ public class Store {
         self.update(entry: entry, setEndedAt: Date(), completion: completion)
     }
     
-    public func update(entry: Entry, setCategory category: Category? = nil, setType type: EntryType? = nil, setStartedAt startedAt: Date? = nil, setEndedAt endedAt: Date? = nil, completion: ((Bool) -> Void)?) {
-        guard category != nil || type != nil || startedAt != nil || endedAt != nil else { completion?(true); return }
+    public func update(entry: Entry, setCategory category: Category? = nil, setType type: EntryType? = nil, setStartedAt startedAt: Date? = nil, setStartedAtTimezone startedAtTimezone: String? = nil, setEndedAt endedAt: Date? = nil, setEndedAtTimezone endedAtTimezone: String? = nil, completion: ((Bool) -> Void)?) {
+        guard category != nil || type != nil || startedAt != nil || startedAtTimezone != nil || endedAt != nil || endedAtTimezone != nil else { completion?(true); return }
         guard endedAt == nil || (endedAt != nil && (entry.type == .range || type == .range)) else { completion?(false); return }
+        guard endedAtTimezone == nil || (endedAtTimezone != nil && (entry.type == .range || type == .range)) else { completion?(false); return }
         
-        self.api.updateEntry(with: entry.id, setCategory: category, setType: type, setStartedAt: startedAt, setEndedAt: endedAt) { (updatedEntry, error) in
+        self.api.updateEntry(with: entry.id, setCategory: category, setType: type, setStartedAt: startedAt, setStartedAtTimezone: startedAtTimezone, setEndedAt: endedAt, setEndedAtTimezone: endedAtTimezone) { (updatedEntry, error) in
             guard error == nil && updatedEntry != nil else {
                 completion?(false)
                 return
@@ -323,7 +324,9 @@ public class Store {
             entry.categoryID = updatedEntry!.categoryID
             entry.type = updatedEntry!.type
             entry.startedAt = updatedEntry!.startedAt
+            entry.startedAtTimezone = updatedEntry!.startedAtTimezone
             entry.endedAt = updatedEntry!.endedAt
+            entry.endedAtTimezone = updatedEntry!.endedAtTimezone
             completion?(true)
         }
     }

--- a/Shared/Models/Entry.swift
+++ b/Shared/Models/Entry.swift
@@ -13,7 +13,9 @@ public class Entry: Codable {
     public var type: EntryType
     public var categoryID: Int
     public var startedAt: Date
+    public var startedAtTimezone: String?
     public var endedAt: Date?
+    public var endedAtTimezone: String?
     
     enum CodingKeys: String, CodingKey
     {
@@ -21,15 +23,19 @@ public class Entry: Codable {
         case type
         case categoryID = "category_id"
         case startedAt = "started_at"
+        case startedAtTimezone = "started_at_timezone"
         case endedAt = "ended_at"
+        case endedAtTimezone = "ended_at_timezone"
     }
     
-    public init(id: Int, type: EntryType, categoryID: Int, startedAt: Date, endedAt: Date?) {
+    public init(id: Int, type: EntryType, categoryID: Int, startedAt: Date, startedAtTimezone: String? = nil, endedAt: Date?, endedAtTimezone: String? = nil) {
         self.id = id
         self.type = type
         self.categoryID = categoryID
         self.startedAt = startedAt
+        self.startedAtTimezone = startedAtTimezone
         self.endedAt = endedAt
+        self.endedAtTimezone = endedAtTimezone
     }
     
     public required convenience init(from decoder: Decoder) throws {
@@ -42,11 +48,13 @@ public class Entry: Codable {
         guard let startedAt: Date = DateHelper.dateFrom(isoString: startedAtString) else {
             throw TimeError.unableToDecodeResponse
         }
+        let startedAtTimezone: String? = try? container.decode(String.self, forKey: .startedAtTimezone)
         
         let endedAtString: String? = try? container.decode(String.self, forKey: .endedAt)
         let endedAt: Date? = endedAtString != nil ? DateHelper.dateFrom(isoString: endedAtString!) : nil
+        let endedAtTimezone: String? = try? container.decode(String.self, forKey: .endedAtTimezone)
 
-        self.init(id: id, type: type, categoryID: categoryID, startedAt: startedAt, endedAt: endedAt)
+        self.init(id: id, type: type, categoryID: categoryID, startedAt: startedAt, startedAtTimezone: startedAtTimezone, endedAt: endedAt, endedAtTimezone: endedAtTimezone)
     }
     
     public func encode(to encoder: Encoder) throws {
@@ -58,8 +66,10 @@ public class Entry: Codable {
         
         let startedAtString: String = DateHelper.isoStringFrom(date: self.startedAt)
         try container.encodeIfPresent(startedAtString, forKey: .startedAt)
+        try container.encodeIfPresent(self.startedAtTimezone, forKey: .startedAtTimezone)
         
         let endedAtString: String? = self.endedAt != nil ? DateHelper.isoStringFrom(date: self.endedAt!) : nil
         try container.encodeIfPresent(endedAtString, forKey: .endedAt)
+        try container.encodeIfPresent(self.endedAtTimezone, forKey: .endedAtTimezone)
     }
 }

--- a/Shared/Network/API+Routes.swift
+++ b/Shared/Network/API+Routes.swift
@@ -115,12 +115,14 @@ extension API {
     }
     
     func recordEvent(for category: Category, completionHandler: @escaping (Entry?, Error?) -> ()) {
-        let body: [String: Any] = ["category_id": category.id, "type": EntryType.event.rawValue]
+        let timezone = TimeZone.autoupdatingCurrent.identifier
+        let body: [String: Any] = ["category_id": category.id, "type": EntryType.event.rawValue, "timezone": timezone]
         POST("/entries", body, auth: true, encoding: .json, completion: completionHandler)
     }
     
     func updateRange(for category: Category, with action: EntryAction, completionHandler: @escaping (Entry?, Error?) -> ()) {
-        let body: [String: Any] = ["category_id": category.id, "type": EntryType.range.rawValue, "action": action.rawValue]
+        let timezone = TimeZone.autoupdatingCurrent.identifier
+        let body: [String: Any] = ["category_id": category.id, "type": EntryType.range.rawValue, "action": action.rawValue, "timezone": timezone]
         POST("/entries", body, auth: true, encoding: .json, completion: completionHandler)
     }
     
@@ -128,13 +130,15 @@ extension API {
         GET("/entries/\(id)", completion: completionHandler)
     }
     
-    func updateEntry(with id: Int, setCategory category: Category? = nil, setType type: EntryType? = nil, setStartedAt startedAt: Date? = nil, setEndedAt endedAt: Date? = nil, completionHandler: @escaping (Entry?, Error?) -> ()) {
+    func updateEntry(with id: Int, setCategory category: Category? = nil, setType type: EntryType? = nil, setStartedAt startedAt: Date? = nil, setStartedAtTimezone startedAtTimezone: String? = nil, setEndedAt endedAt: Date? = nil, setEndedAtTimezone endedAtTimezone: String? = nil, completionHandler: @escaping (Entry?, Error?) -> ()) {
         
         var body: [String: Any] = [:]
         if category != nil { body["category_id"] = category!.id }
         if type != nil { body["type"] = type!.rawValue }
         if startedAt != nil { body["started_at"] = DateHelper.isoStringFrom(date: startedAt!) }
+        if startedAtTimezone != nil { body["started_at_timezone"] = startedAtTimezone }
         if endedAt != nil { body["ended_at"] = DateHelper.isoStringFrom(date: endedAt!) }
+        if endedAtTimezone != nil { body["ended_at_timezone"] = endedAtTimezone }
         
         PUT("/entries/\(id)", body, completion: completionHandler)
     }

--- a/Shared/Tests/Test_Entry.swift
+++ b/Shared/Tests/Test_Entry.swift
@@ -13,13 +13,17 @@ class Test_Entry: XCTestCase {
     
     func test_decodable() {
         let startString = "2019-02-25T03:09:53.394Z"
+        let startTimezone = "America/Chicago"
         let endString = "2019-02-27T02:08:53.394Z"
+        let endTimezone = "America/Chicago"
         let entryDictionary: [String: Any] = [
             "id": 15,
             "type": "range",
             "category_id": 16,
             "started_at": startString,
-            "ended_at": endString
+            "started_at_timezone": startTimezone,
+            "ended_at": endString,
+            "ended_at_timezone": endTimezone
         ]
         guard let entryData = try? JSONSerialization.data(
             withJSONObject: entryDictionary,
@@ -42,11 +46,13 @@ class Test_Entry: XCTestCase {
             DateHelper.dateFrom(isoString: startString)?.timeIntervalSinceReferenceDate ?? -200,
             accuracy: 1.0
         )
+        XCTAssertEqual(entry.startedAtTimezone, startTimezone)
         XCTAssertEqual(
             entry.endedAt?.timeIntervalSinceReferenceDate ?? -100,
             DateHelper.dateFrom(isoString: endString)?.timeIntervalSinceReferenceDate ?? -200,
             accuracy: 1.0
         )
+        XCTAssertEqual(entry.endedAtTimezone, endTimezone)
     }
     
     func test_decodableError() {
@@ -77,8 +83,9 @@ class Test_Entry: XCTestCase {
         let type = EntryType.event
         let categoryID = 17
         let startedAt = Date()
+        let startedAtTimezone = "America/Chicago"
         
-        let entry = Entry(id: id, type: type, categoryID: categoryID, startedAt: startedAt, endedAt: nil)
+        let entry = Entry(id: id, type: type, categoryID: categoryID, startedAt: startedAt, startedAtTimezone: startedAtTimezone, endedAt: nil)
         
         guard let encodedEntry = try? JSONEncoder().encode(entry) else {
             XCTFail("Entry could not be encoded")
@@ -98,5 +105,8 @@ class Test_Entry: XCTestCase {
             decodedEntry.startedAt.timeIntervalSinceReferenceDate,
             accuracy: 0.001
         )
+        XCTAssertEqual(entry.startedAtTimezone, startedAtTimezone)
+        XCTAssertNil(entry.endedAt)
+        XCTAssertNil(entry.endedAtTimezone)
     }
 }

--- a/Shared/Tests/Test_Store.swift
+++ b/Shared/Tests/Test_Store.swift
@@ -732,7 +732,7 @@ class Test_Store: XCTestCase {
         }
         waitForExpectations(timeout: 5, handler: nil)
         
-        XCTAssertEqual(timeElapsed, 0, accuracy: 0.0001)
+        XCTAssertEqual(timeElapsed, 0, accuracy: 0.0002)
     }
     
     func test_17_isOpenFalseAfterToggleOnOpen() {

--- a/iOS/iOS/EntriesViewController+Alerts.swift
+++ b/iOS/iOS/EntriesViewController+Alerts.swift
@@ -118,8 +118,15 @@ extension EntriesViewController: UIPickerViewDelegate, UIPickerViewDataSource {
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
 
         let picker = UIDatePicker(frame: CGRect(x: 5, y: 30, width: 250, height: 160))
+        picker.timeZone = (
+            startTime
+                ? (entry.startedAtTimezone != nil ? TimeZone(identifier: entry.startedAtTimezone!) : nil)
+                : (entry.endedAtTimezone != nil ? TimeZone(identifier: entry.endedAtTimezone!) : nil)
+            ) ?? TimeZone.autoupdatingCurrent
         picker.date = startTime ? entry.startedAt : entry.endedAt ?? Date()
         alert.view.addSubview(picker)
+        if !startTime { picker.minimumDate = entry.startedAt }
+        if startTime && entry.endedAt != nil { picker.maximumDate = entry.endedAt }
         
         let cancelTitle = NSLocalizedString("Cancel", comment: "")
         let cancelAction = UIAlertAction(title: cancelTitle, style: .cancel) { _ in

--- a/iOS/iOS/EntriesViewController.swift
+++ b/iOS/iOS/EntriesViewController.swift
@@ -19,7 +19,7 @@ class EntriesViewController: UIViewController, UITableViewDelegate, UITableViewD
     var dateFormatters: [String:DateFormatter] = [:]
     
     // +Alerts Support
-    var categoryPickerData: [(String,Any?)] = []
+    var pickerData: [(String,Any?)] = []
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -87,8 +87,8 @@ class EntriesViewController: UIViewController, UITableViewDelegate, UITableViewD
     }
     
     func edit(entry: Entry, at indexPath: IndexPath,  completion: @escaping (Bool) -> Void) {
-        self.showAlertFor(editing: entry) { (newCategoryID, newEntryType, newStartDate, newEndDate) in
-            guard newCategoryID != nil || newEntryType != nil || newStartDate != nil || newEndDate != nil else {
+        self.showAlertFor(editing: entry) { (newCategoryID, newEntryType, newStartDate, newStartTimezone, newEndDate, newEndTimezone) in
+            guard newCategoryID != nil || newEntryType != nil || newStartDate != nil || newEndDate != nil || newStartTimezone != nil || newEndTimezone != nil else {
                 DispatchQueue.main.async {
                     completion(false)
                 }
@@ -102,7 +102,9 @@ class EntriesViewController: UIViewController, UITableViewDelegate, UITableViewD
                 setCategory: newCategory,
                 setType: newEntryType,
                 setStartedAt: newStartDate,
-                setEndedAt: newEndDate
+                setStartedAtTimezone: newStartTimezone,
+                setEndedAt: newEndDate,
+                setEndedAtTimezone: newEndTimezone
             ) { (success) in
                 DispatchQueue.main.async {
                     if newStartDate != nil {

--- a/iOS/iOS/EntriesViewController.swift
+++ b/iOS/iOS/EntriesViewController.swift
@@ -249,7 +249,7 @@ class EntriesViewController: UIViewController, UITableViewDelegate, UITableViewD
         let defaultTimezone = TimeZone.autoupdatingCurrent
         let safeTimezone = timezoneIdentifier ?? defaultTimezone.identifier
         if (self.dateFormatters[safeTimezone] == nil) {
-            let timezone = TimeZone.init(identifier: safeTimezone) ?? defaultTimezone
+            let timezone = TimeZone(identifier: safeTimezone) ?? defaultTimezone
             if (self.dateFormatters[timezone.identifier] == nil) {
                 let newFormatter = DateFormatter.init()
                 newFormatter.dateFormat = "MM/dd/YY hh:mm a zzz"


### PR DESCRIPTION
# 💚 Summary

* Add support for timezones to `Entry` model
* Include local timezone in log/start/stop requests at the API layer
* Allow timezone to be changed through the `Entry` directly and updated in the store
* Display entries in recorded timezones instead of local device timezone