### PR TITLE
Fix Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ cache:
     - Time-API/node_modules
 
 before_install:
+  - brew update
   - brew install mysql@5.7
   - brew tap homebrew/services
   - brew services start mysql@5.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,8 @@ cache:
     - Time-API/node_modules
 
 before_install:
-  - brew update
   - brew install mysql@5.7
-  - brew tap homebrew/services
-  - brew services start mysql@5.7
+  - /usr/local/opt/mysql@5.7/bin/mysql.server start
   - brew link mysql@5.7 --force
 
 install:


### PR DESCRIPTION
# 💚 Fix Travis Build

## Problem

Travis has an old version of homebrew/services that is not correctly starting mysql@5.7

## Solution

1. Force update brew (this adds about 1.5m to the build time)
2. Force start mysql without brew/services

## Details

Both tests were used. Brew update is too slow, but I'm keeping both commits in as an example of the solutions.