### PR TITLE
Usability Improvements

### DIFF
--- a/Shared/Interface/Store.swift
+++ b/Shared/Interface/Store.swift
@@ -68,6 +68,13 @@ public class Store {
         self.api = api
         self.restoreDataFromDisk()
         self.hasInitialized = true
+        
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(categoryArchiveRequested),
+            name: .TimeCategoryArchiveRequested,
+            object: nil
+        )
     }
     
     // MARK: - System Queues
@@ -403,7 +410,6 @@ public class Store {
             
             completion?(true)
         }
-        
     }
     
     public func isRangeOpen(for category: TimeSDK.Category) -> Bool? {
@@ -573,6 +579,15 @@ public class Store {
     }
     
     // MARK: - Archival Support and Integration
+    
+    @objc private func categoryArchiveRequested(notification: NSNotification) {
+        // Only trigger archive for categories managed by store
+        guard
+            let category = notification.object as? Category,
+            self.categories.contains(category)
+        else { return }
+        self.archive(data: self.categories)
+    }
     
     public func resetDisk() {
         _ = Archive.removeAllData()

--- a/Shared/Interface/TimeNotification.swift
+++ b/Shared/Interface/TimeNotification.swift
@@ -12,6 +12,8 @@ extension Notification.Name {
     static let TimeAPIAutoRefreshedToken = Notification.Name("TimeAPIAutoRefreshedToken")
     static let TimeAPIAutoRefreshFailed = Notification.Name("TimeAPIAutoRefreshFailed")
     
+    public static let TimeCategoryArchiveRequested = Notification.Name("TimeCategoryArchiveRequested")
+    
     public static let TimeUserSignInNeeded = Notification.Name("TimeUserSignInNeeded")
     public static let TimeUnableToReachServer = Notification.Name("TimeUnableToReachServer")
     

--- a/Shared/Models/Category.swift
+++ b/Shared/Models/Category.swift
@@ -14,12 +14,27 @@ public class Category: Codable, Equatable {
     public var accountID: Int
     public var name: String
     
+    private var _expanded: Bool = false
+    internal var expanded: Bool {
+        get { return self._expanded }
+        set {
+            guard self._expanded != newValue else { return }
+            
+            self._expanded = newValue
+            NotificationCenter.default.post(name: .TimeCategoryArchiveRequested, object: self)
+        }
+    }
+    
     enum CodingKeys: String, CodingKey
     {
+        /* API Fields */
         case id
         case parentID = "parent_id"
         case accountID = "account_id"
         case name
+
+        /* Internal */
+        case _expanded = "_expanded"
     }
     
     init(id: Int, parentID: Int?, accountID: Int, name: String) {
@@ -27,6 +42,20 @@ public class Category: Codable, Equatable {
         self.parentID = parentID
         self.accountID = accountID
         self.name = name
+    }
+    
+    public required init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        
+        self.id = try values.decode(Int.self, forKey: .id)
+        self.parentID = try? values.decode(Int.self, forKey: .parentID)
+        self.accountID = try values.decode(Int.self, forKey: .accountID)
+        self.name = try values.decode(String.self, forKey: .name)
+        
+        if values.contains(._expanded) {
+            // Set directly to avoid setter on init
+            self._expanded = try values.decode(Bool.self, forKey: ._expanded)
+        }
     }
     
     public static func ==(lhs: Category, rhs: Category) -> Bool {

--- a/Shared/Models/CategoryTree.swift
+++ b/Shared/Models/CategoryTree.swift
@@ -21,8 +21,7 @@ public class CategoryTree: Equatable {
         return self.parent == nil ? 0 : self.parent!.depth + 1
     }
     
-    private var _expanded: Bool = false
-    public var expanded: Bool { return self._expanded }
+    public var expanded: Bool { return self.node.expanded }
     
     // MARK: - Init
     
@@ -37,14 +36,14 @@ public class CategoryTree: Equatable {
     
     public func toggleExpanded(forceTo goal: Bool? = nil) {
         guard self.children.count > 0 else {
-            self._expanded = false
+            self.node.expanded = false
             return
         }
         
         if goal == nil {
-            self._expanded = !self.expanded
+            self.node.expanded = !self.expanded
         } else {
-            self._expanded = goal!
+            self.node.expanded = goal!
         }
     }
     

--- a/iOS/iOS/EntriesViewController.swift
+++ b/iOS/iOS/EntriesViewController.swift
@@ -262,7 +262,14 @@ class EntriesViewController: UIViewController, UITableViewDelegate, UITableViewD
         } else if entry.endedAt == nil {
             timeText = "\(startedAtString) - \(NSLocalizedString("Present", comment: ""))"
         } else {
-            timeText = "\(startedAtString) - \(endedAtString!)"
+            // Depends on stable string formatting
+            let sameDay = endedAtString != nil && (startedAtString.prefix(8) == endedAtString!.prefix(8))
+            if !sameDay {
+                timeText = "\(startedAtString) - \(endedAtString!)"
+            } else {
+                let endedAtWithoutDate = endedAtString!.dropFirst(9)
+                timeText = "\(startedAtString) - \(endedAtWithoutDate)"
+            }
         }
         return timeText
     }


### PR DESCRIPTION
# Completed Improvements

* Added ability for `CategoryTree` to remember positions
    * Added support for archives to be requested. Additional metadata can now be modified by the Store and archives can be triggered as a result of that (separate from the core network chain).
    * Moved `expanded` from `CategoryTree` to `Category` so that it can be used in the archive loop
* Hide endedAt date from entry lists if the date is the same

# Other planned features

[ ] Indication on the device home screen if timers are running
[ ] Quick button to start/stop/record most recent n categories
[ ] Summary of last week + today
[ ] Event/Range duration indication

--> All of these features are UI-focused by nature. I can structure some of them in, but I do not want to shoehorn something into the current VC stack and have to rewrite it completely for the new stack. It seems best to just close this PR (far short of what was planned) and start on actually building and polishing the UI and true VC structure