### PR TITLE
Add Support for Live Widget Data

### DIFF
--- a/Shared/Tests/Test_0_Setup.swift
+++ b/Shared/Tests/Test_0_Setup.swift
@@ -28,7 +28,7 @@ class Test_0_Setup: XCTestCase {
             userExists = token != nil
             loginUserExpectation.fulfill()
         }
-        waitForExpectations(timeout: 5, handler: nil)
+        waitForExpectations(timeout: 15, handler: nil)
         
         guard !userExists else { return }
 
@@ -37,7 +37,7 @@ class Test_0_Setup: XCTestCase {
         API.shared.createUser(withEmail: email, andPassword: password) { (user, error) in
             createUserExpectation.fulfill()
         }
-        waitForExpectations(timeout: 5, handler: nil)
+        waitForExpectations(timeout: 15, handler: nil)
     }
     
     func test_1_configureSharedTime() {

--- a/Shared/Tests/Test_API.swift
+++ b/Shared/Tests/Test_API.swift
@@ -34,13 +34,13 @@ class Test_API: XCTestCase {
         api.createUser(withEmail: email, andPassword: password) { (user, error) in
             createExpectation.fulfill()
         }
-        waitForExpectations(timeout: 5, handler: nil)
+        waitForExpectations(timeout: 15, handler: nil)
         
         let loginExpectation = self.expectation(description: "loginUser")
         api.getToken(withEmail: email, andPassword: password) { (user, error) in
             loginExpectation.fulfill()
         }
-        waitForExpectations(timeout: 5, handler: nil)
+        waitForExpectations(timeout: 15, handler: nil)
     }
     
     func test_rejectsAllRequestsWithBadBaseURL() {

--- a/iOS/Widget/Widget.swift
+++ b/iOS/Widget/Widget.swift
@@ -45,8 +45,8 @@ struct SummaryWidget: Widget {
 
 struct TimeLoader {
     static func fetch(completion: @escaping (Result<TimeStatus, Error>) -> Void) {
-        var dayTime: String? = nil
-        var weekTime: String? = nil
+        var dayQuantity: TimeQuantity? = nil
+        var weekQuantity: TimeQuantity? = nil
         var isActive = false
         
         let now = Date()
@@ -59,9 +59,9 @@ struct TimeLoader {
         let startOfWeek = calendar.date(from: weekComps)!
         
         let doneWithRange = {
-            guard dayTime != nil && weekTime != nil else { return }
+            guard dayQuantity != nil && weekQuantity != nil else { return }
             
-            let status = TimeStatus(today: dayTime!, week: weekTime!, active: isActive)
+            let status = TimeStatus(today: dayQuantity!, week: weekQuantity!, active: isActive)
             completion(.success(status))
         }
         
@@ -83,15 +83,15 @@ struct TimeLoader {
             }
             
             // Check day total
-            self.getFrom(date: startOfDay) { (dayString, active) in
-                dayTime = dayString
+            self.getFrom(date: startOfDay) { (day, active) in
+                dayQuantity = day
                 isActive = isActive || active
 
                 doneWithRange()
             }
             // Check week total
-            self.getFrom(date: startOfWeek) { (weekString, active) in
-                weekTime = weekString
+            self.getFrom(date: startOfWeek) { (week, active) in
+                weekQuantity = week
                 isActive = isActive || active
 
                 doneWithRange()
@@ -99,10 +99,10 @@ struct TimeLoader {
         }
     }
     
-    static internal func getFrom(date: Date, completion: @escaping (String, Bool) -> ()) {
+    static internal func getFrom(date: Date, completion: @escaping (TimeQuantity?, Bool) -> ()) {
         Time.shared.store.getEntries(after: date) { (entries: [Entry]?, error: Error?) -> () in
             guard entries != nil && error == nil else {
-                completion("XX:XX:XX", false)
+                completion(TimeQuantity.unknown, false)
                 return
             }
             
@@ -118,26 +118,64 @@ struct TimeLoader {
                 return entry.endedAt!.timeIntervalSince(entry.startedAt)
             }).reduce(0) { $0 + $1 }
             
-            let getTimeString = { (time: Int) -> String in
+            let getTimeQuantity = { (time: Int) -> TimeQuantity in
                 let seconds = (time % 60)
                 let minutes = (time / 60) % 60
                 let hours = (time / 3600)
                 
-                let showSeconds = true // TODO: Use app settings
-                let timeString = showSeconds
-                    ? String(format: "%02d:%02d:%02d", hours, minutes, seconds)
-                    : String(format: "%02d:%02d", hours, minutes)
-                return timeString
+                return TimeQuantity(hours: hours, minutes: minutes, seconds: seconds)
             }
             
-            completion(getTimeString(Int(totalTime)), isActive)
+            completion(getTimeQuantity(Int(totalTime)), isActive)
         }
     }
 }
 
+struct TimeQuantity {
+    let hours: Int
+    let minutes: Int
+    let seconds: Int
+    
+    var frozenDisplayValue: String {
+        guard !self.isUnknown else { return "XX:XX:XX" }
+        
+        let showSeconds = true
+        let timeString = showSeconds // TODO: Use app settings
+            ? String(format: "%02d:%02d:%02d", hours, minutes, seconds)
+            : String(format: "%02d:%02d", hours, minutes)
+        return timeString
+    }
+    
+    var activeRelativeDate: Date {
+        let components = DateComponents(hour: -self.hours, minute: -self.minutes, second: -self.seconds)
+        let pastDate = Calendar.current.date(byAdding: components, to: Date())!
+        return pastDate
+    }
+    
+    var activePrefix: String {
+        if hours >= 10 {
+            return ""
+        } else if hours >= 1 {
+            return "0"
+        } else if minutes >= 10 {
+            return "00:"
+        } else {
+            return "00:0"
+        }
+    }
+    
+    var isUnknown: Bool {
+        return self.hours == -1
+    }
+    
+    static var unknown: TimeQuantity {
+        return TimeQuantity(hours: -1, minutes: -1, seconds: -1)
+    }
+}
+
 struct TimeStatus {
-    let today: String
-    let week: String
+    let today: TimeQuantity
+    let week: TimeQuantity
     let active: Bool
 }
 
@@ -150,14 +188,18 @@ struct TimeTimeline: TimelineProvider {
     typealias Entry = TimeEntry
     
     public func placeholder(in context: Context) -> TimeEntry {
-        let fakeStatus = TimeStatus(today: "01:38:04", week: "53:43:59", active: true)
+        let today = TimeQuantity(hours: 1, minutes: 38, seconds: 04)
+        let week = TimeQuantity(hours: 53, minutes: 43, seconds: 59)
+        let fakeStatus = TimeStatus(today: today, week: week, active: true)
         let entry = TimeEntry(date: Date(), status: fakeStatus)
         return entry
     }
     
     // Fake information for previews
     public func getSnapshot(in context: Context, completion: @escaping (TimeEntry) -> Void) {
-        let fakeStatus = TimeStatus(today: "01:38:04", week: "53:43:59", active: true)
+        let today = TimeQuantity(hours: 1, minutes: 38, seconds: 04)
+        let week = TimeQuantity(hours: 53, minutes: 43, seconds: 59)
+        let fakeStatus = TimeStatus(today: today, week: week, active: true)
         let entry = TimeEntry(date: Date(), status: fakeStatus)
         completion(entry)
     }
@@ -173,7 +215,8 @@ struct TimeTimeline: TimelineProvider {
             if case .success(let fetchedStatus) = result {
                 status = fetchedStatus
             } else {
-                status = TimeStatus(today: "00:00:00", week: "00:00:00", active: false)
+                let zeroDay = TimeQuantity(hours: 0, minutes: 0, seconds: 0)
+                status = TimeStatus(today: zeroDay, week: zeroDay, active: false)
             }
             let entry = TimeEntry(date: currentDate, status: status)
             let timeline = Timeline(entries: [entry], policy: .after(status.active ? earlyDate : farDate))
@@ -186,26 +229,40 @@ struct TimeWidgetView : View {
     let entry: TimeEntry
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
-            VStack(alignment: .leading, spacing: 4, content: {
-                Text(entry.status.today)
-                    .font(Font.system(size: 24.0, weight: .regular, design: .default).monospacedDigit())
-                    .foregroundColor(entry.status.active ? Theme.active : Theme.label)
-                Text("Today")
-                    .font(Font.system(size: 10.0, weight: .regular, design: .default))
-                    .foregroundColor(Theme.label)
-            })
+            getBlock("Today", value: entry.status.today, active: entry.status.active)
             Spacer()
-            VStack(alignment: .leading, spacing: 4, content: {
-                Text(entry.status.week)
-                    .font(Font.system(size: 24.0, weight: .regular, design: .default).monospacedDigit())
-                    .foregroundColor(entry.status.active ? Theme.active : Theme.label)
-                Text("This Week")
-                    .font(Font.system(size: 10.0, weight: .regular, design: .default))
-                    .foregroundColor(Theme.label)
-            })
+            getBlock("This Week", value: entry.status.week, active: entry.status.active)
         }
         .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity, alignment: .leading)
         .padding()
         .background(Theme.background)
+    }
+    
+    func getBlock(_ title: String, value: TimeQuantity, active: Bool) -> some View {
+        return VStack(alignment: .leading, spacing: 4, content: {
+            (
+                active
+                    ? (Text(value.activePrefix) + Text(value.activeRelativeDate, style: .timer))
+                    : Text(value.frozenDisplayValue)
+            )
+                .font(Font.system(size: 24.0, weight: .regular, design: .default).monospacedDigit())
+                .foregroundColor(active ? Theme.active : Theme.label)
+            Text(title)
+                .font(Font.system(size: 10.0, weight: .regular, design: .default))
+                .foregroundColor(Theme.label)
+        })
+    }
+}
+
+struct TimeWidgetView_Previews: PreviewProvider {
+    static var previews: some View {
+        TimeWidgetView(entry: TimeEntry(
+            date: Date(),
+            status: TimeStatus(
+                today: TimeQuantity(hours: 0, minutes: 6, seconds: 36),
+                week: TimeQuantity(hours: 11, minutes: 22, seconds: 33),
+                active: true
+            )
+        )).previewContext(WidgetPreviewContext(family: .systemSmall))
     }
 }


### PR DESCRIPTION
## Summary

Instead of refreshing the widget data every 5 minutes while running use the `Text(:,style: .timer)` SwiftUI field to show live time information.

This will show live information in the correct format by appending a prefix to the dynamically updating text data.

It is not possible to overlay (`ZStack`) the live data with `00:00:00` and just set a background color to mask the unneeded `0`'s because the live updating Text fields are always full width when used in a widget. When setting the background on a full width object, it colors the entire view instead of just the areas with text.

## Detailed Implementation

`Text(:, style: .timer)` shows information in the format of:

* Under 1 minute: `0:xx`
* Under 10 minutes: `x:xx`
* Under 1 hour: `xx:xx`
* Under 10 hours: `x:xx:xx`
* Under 100 hours: `xx:xx:xx`

For the purposes of the existing time metrics and information, all metrics are shown in the `xx:xx:xx` format. To match the full format, when active timers are displayed using the live `Text` objects with a prefix of the additional padding.

To make sure that the running and paused time formats match and to avoid issues with incorrect prefixes:

* `00:0` + `1:34` = `00:01:34` (happy path)
* `00:0` + `10:00` = `00:010:00` (at ten min transition)

Updates are scheduled in advance to change the `TimelineEntry` data when the display format transitions are scheduled to take place.

## Other Changes

Remove `TimeStatus` and merge directly into `TimeEntry`. Some SwiftUI rendering is processed in advance of actual display (0-30s) so the exact time that a `TimeQuantity` will occur (for future measurements) is needed to display all items properly. 