### PR TITLE
Category analytics

### DIFF
--- a/Shared/Interface/Analyzer.swift
+++ b/Shared/Interface/Analyzer.swift
@@ -52,6 +52,16 @@ public class Analyzer {
             return timeString
         }
         
+        public func displayDurationAndOrEvents(withSeconds showSeconds: Bool) -> String {
+            if duration != 0 && events != 0 {
+                return "(\(events)) \(self.displayDuration(withSeconds: showSeconds))"
+            } else if duration != 0 {
+                return self.displayDuration(withSeconds: showSeconds)
+            } else {
+                return self.events.description + " event" + (self.events != 1 ? "s" : "")
+            }
+        }
+        
         private init(operation: Operation, categoryID: Int?, duration: TimeInterval, events: Int, open: Bool) {
             self.operation = operation
             self.categoryID = categoryID

--- a/Shared/Interface/Analyzer.swift
+++ b/Shared/Interface/Analyzer.swift
@@ -113,7 +113,7 @@ public class Analyzer {
     
     public func evaluateAll(
         in calendar: Calendar? = nil,
-        gropuBy: TimePeriod,
+        groupBy: TimePeriod,
         perform operations: [Operation],
         includeEmpty: Bool = false
     ) -> [String: [Result]] {
@@ -123,7 +123,7 @@ public class Analyzer {
         let to: Date? = nil // now
         
         // 2. Perfor query
-        return self.evaluate(from: from, to: to, in: selectedCalendar, groupBy: gropuBy, perform: operations, includeEmpty: includeEmpty)
+        return self.evaluate(from: from, to: to, in: selectedCalendar, groupBy: groupBy, perform: operations, includeEmpty: includeEmpty)
     }
         
     public func evaluate(

--- a/Shared/Interface/Analyzer.swift
+++ b/Shared/Interface/Analyzer.swift
@@ -14,7 +14,7 @@ public class Analyzer {
     private var lowMemoryMode: Bool
     
     // Internal Cache
-    private var closedRanges: [Entry] = []
+    private var closedEntries: [Entry] = []
     private var openRanges: [Entry] = []
     
     private var closedAnalysis: AnalysisCache? = nil {
@@ -36,6 +36,7 @@ public class Analyzer {
         public var operation: Operation
         public var categoryID: Int?
         public var duration: TimeInterval
+        public var events: Int
         public var open: Bool
         
         public func displayDuration(withSeconds showSeconds: Bool) -> String {
@@ -51,23 +52,24 @@ public class Analyzer {
             return timeString
         }
         
-        private init(operation: Operation, categoryID: Int?, duration: TimeInterval, open: Bool) {
+        private init(operation: Operation, categoryID: Int?, duration: TimeInterval, events: Int, open: Bool) {
             self.operation = operation
             self.categoryID = categoryID
             self.duration = duration
+            self.events = events
             self.open = open
         }
         
         public init() {
-            self.init(operation: .none, categoryID: nil, duration: 0, open: false)
+            self.init(operation: .none, categoryID: nil, duration: 0, events: 0, open: false)
         }
         
-        fileprivate init(overallTotal duration: TimeInterval, open: Bool) {
-            self.init(operation: .calculateTotal, categoryID: nil, duration: duration, open: open)
+        fileprivate init(overallTotal duration: TimeInterval, events: Int, open: Bool) {
+            self.init(operation: .calculateTotal, categoryID: nil, duration: duration, events: events, open: open)
         }
         
-        fileprivate init(categoryTotal duration: TimeInterval, forID categoryID: Int, open: Bool) {
-            self.init(operation: .calculatePerCategory, categoryID: categoryID, duration: duration, open: open)
+        fileprivate init(categoryTotal duration: TimeInterval, events: Int, forID categoryID: Int, open: Bool) {
+            self.init(operation: .calculatePerCategory, categoryID: categoryID, duration: duration, events: events, open: open)
         }
     }
     
@@ -197,10 +199,13 @@ public class Analyzer {
         let lowMemoryFilterStart = Calendar.current.date(byAdding: .day, value: -10, to: Date())!
         
         // 1. Split open and closed ranges
-        var closedRanges: [Entry] = []
+        var closedEntries: [Entry] = []
         var openRanges: [Entry] = []
         store.entries.forEach { (entry) in
-            guard entry.type == .range else { return }
+            guard entry.type == .range else {
+                closedEntries.append(entry)
+                return
+            }
             
             if entry.endedAt == nil {
                 openRanges.append(entry)
@@ -208,22 +213,22 @@ public class Analyzer {
                 !self.lowMemoryMode ||
                 (self.lowMemoryMode && entry.endedAt! > lowMemoryFilterStart)
             ) {
-                closedRanges.append(entry)
+                closedEntries.append(entry)
             }
         }
         
-        self.closedRanges = closedRanges
+        self.closedEntries = closedEntries
         self.openRanges = openRanges
         
         // 2. Analyze all closed entries
-        let closedAnalysis = self.closedRanges.map(EntryAnalysis.generate(for:))
+        let closedAnalysis = self.closedEntries.map(EntryAnalysis.generate(for:))
         
         // 3. Format and cache closed entries for date-based lookup
         self.closedAnalysis = AnalysisCache(from: closedAnalysis)
     }
     
     private func clearCache() {
-        self.closedRanges = []
+        self.closedEntries = []
         self.openRanges = []
         
         self.closedAnalysis = nil
@@ -236,21 +241,25 @@ public class Analyzer {
             var results: [Result] = []
             if operations.contains(.calculateTotal) {
                 let totalDuration = data.reduce(0, { $0 + $1.duration })
+                let totalEvents = data.reduce(0, { $0 + $1.events })
                 let totalOpen = data.reduce(false, { $0 || $1.open })
 
-                results.append(Result(overallTotal: totalDuration, open: totalOpen))
+                results.append(Result(overallTotal: totalDuration, events: totalEvents, open: totalOpen))
             }
             
             if operations.contains(.calculatePerCategory) {
                 let durationByCategory: [Int: TimeInterval] = data.reduce(into: [:]) { (object, record) in
                     object[record.categoryID] = (object[record.categoryID] ?? 0) + record.duration
                 }
+                let eventsByCategory: [Int: Int] = data.reduce(into: [:]) { (object, record) in
+                    object[record.categoryID] = (object[record.categoryID] ?? 0) + record.events
+                }
                 let openByCategory: [Int: Bool] = data.reduce(into: [:]) { (object, record) in
                     object[record.categoryID] = (object[record.categoryID] ?? false) || record.open
                 }
                 
                 let categoryResults = durationByCategory.keys.map { (key) -> Result in
-                    return Result(categoryTotal: durationByCategory[key]!, forID: key, open: openByCategory[key]!)
+                    return Result(categoryTotal: durationByCategory[key]!, events: eventsByCategory[key]!, forID: key, open: openByCategory[key]!)
                 }
                 
                 results.append(contentsOf: categoryResults)
@@ -267,26 +276,29 @@ public class Analyzer {
             let totalA = collideA.first(where: { $0.operation == .calculateTotal })
             let totalB = collideB.first(where: { $0.operation == .calculateTotal })
             
-            if let newTotal: TimeInterval = totalA == nil && totalB == nil ? nil : (totalA?.duration ?? 0) + (totalB?.duration ?? 0) {
+            if let newTotal: TimeInterval = totalA == nil && totalB == nil ? nil : (totalA?.duration ?? 0) + (totalB?.duration ?? 0),
+               let newEventsTotal: Int = totalA == nil && totalB == nil ? nil : (totalA?.events ?? 0) + (totalB?.events ?? 0) {
                 let totalOpen: Bool = (totalA?.open ?? false) || (totalB?.open ?? false)
-                merged.append(Result(overallTotal: newTotal, open: totalOpen))
+                merged.append(Result(overallTotal: newTotal, events: newEventsTotal, open: totalOpen))
             }
             
             var byCategory = collideA.filter({ $0.operation == .calculatePerCategory })
             byCategory.append(contentsOf: collideB.filter({ $0.operation == .calculatePerCategory }))
 
             var categoryTotals: [Int: TimeInterval] = [:]
+            var categoryEventTotals: [Int: Int] = [:]
             var categoriesOpen: [Int: Bool] = [:]
             byCategory.forEach { (record) in
                 // Error. Skip invalid category records
                 guard record.categoryID != nil else { return }
                 
                 categoryTotals[record.categoryID!] = (categoryTotals[record.categoryID!] ?? 0) + record.duration
+                categoryEventTotals[record.categoryID!] = (categoryEventTotals[record.categoryID!] ?? 0) + record.events
                 categoriesOpen[record.categoryID!] = (categoriesOpen[record.categoryID!] ?? false) || record.open
             }
             
             let newCategoryResults = categoryTotals.keys.map { (key) -> Result in
-                return Result(categoryTotal: categoryTotals[key]!, forID: key, open: categoriesOpen[key]!)
+                return Result(categoryTotal: categoryTotals[key]!, events: categoryEventTotals[key]!, forID: key, open: categoriesOpen[key]!)
             }
             
             merged.append(contentsOf: newCategoryResults)

--- a/Shared/Tests/Test_AnalysisCache.swift
+++ b/Shared/Tests/Test_AnalysisCache.swift
@@ -71,7 +71,7 @@ class Test_AnalysisCache: XCTestCase {
         // requires a search of the start, and exclusion of tomorrow
         
         XCTAssertEqual(sameDay.count, 0)
-        XCTAssertEqual(noEnd.count, 23) // All data in cache
+        XCTAssertEqual(noEnd.count, 25) // All data in cache
         
         XCTAssertEqual(endNextDay.count, 1)
         XCTAssertEqual(endNextDay.keys.first ?? "--", "2020-11-03")
@@ -106,7 +106,7 @@ class Test_AnalysisCache: XCTestCase {
             groupingBy: .day,
             with: calendar)
         
-        XCTAssertEqual(dataByDay.count, 24) // Data exists for 24 days
+        XCTAssertEqual(dataByDay.count, 26) // Data exists for 26 days
     }
     
     func test_wholeRangeByWeek() {
@@ -143,12 +143,12 @@ class Test_AnalysisCache: XCTestCase {
             return
         }
         
-        XCTAssertEqual(finalWeek.count, 3)
+        XCTAssertEqual(finalWeek.count, 5)
         
-        let expectedIDs = [3126, 3127, 3128]
+        let expectedIDs = [3127, 3128, 3130, 3126, 3131]
         XCTAssertEqual(Set(finalWeek.map({ $0.entryID })), Set(expectedIDs))
         
-        let expectedDurations: [TimeInterval] = [1980.0, 18022.0, 35129.0]
+        let expectedDurations: [TimeInterval] = [0.0, 1980.0, 18022.0, 35129.0]
         XCTAssertEqual(Set(finalWeek.map({ $0.duration })), Set(expectedDurations))
     }
     

--- a/Shared/Tests/Test_Analyzer.swift
+++ b/Shared/Tests/Test_Analyzer.swift
@@ -75,6 +75,7 @@ class Test_Analyzer: XCTestCase {
         
         XCTAssertEqual(firstOperation.operation, .calculateTotal)
         XCTAssertEqual(firstOperation.duration, 675927)
+        XCTAssertEqual(firstOperation.events, 6)
         XCTAssertEqual(firstOperation.categoryID, nil)
         XCTAssertEqual(firstOperation.open, false)
     }
@@ -119,14 +120,19 @@ class Test_Analyzer: XCTestCase {
             switch result.categoryID {
             case 5:
                 XCTAssertEqual(result.duration, 2195)
+                XCTAssertEqual(result.events, 0)
             case 14:
                 XCTAssertEqual(result.duration, 593)
+                XCTAssertEqual(result.events, 0)
             case 28:
                 XCTAssertEqual(result.duration, 2757)
+                XCTAssertEqual(result.events, 0)
             case 37:
                 XCTAssertEqual(result.duration, 3772)
+                XCTAssertEqual(result.events, 2)
             case 38:
                 XCTAssertEqual(result.duration, 666610)
+                XCTAssertEqual(result.events, 4)
             default:
                 XCTFail("Unknown category id")
             }
@@ -179,14 +185,19 @@ class Test_Analyzer: XCTestCase {
             switch result.categoryID {
             case 5:
                 XCTAssertEqual(result.duration, 2195)
+                XCTAssertEqual(result.events, 0)
             case 14:
                 XCTAssertEqual(result.duration, 593)
+                XCTAssertEqual(result.events, 0)
             case 28:
                 XCTAssertEqual(result.duration, 2757)
+                XCTAssertEqual(result.events, 0)
             case 37:
                 XCTAssertEqual(result.duration, 3772)
+                XCTAssertEqual(result.events, 2)
             case 38:
                 XCTAssertEqual(result.duration, 666610)
+                XCTAssertEqual(result.events, 4)
             default:
                 XCTFail("Unknown category id")
             }
@@ -235,14 +246,19 @@ class Test_Analyzer: XCTestCase {
             switch date {
             case "2020-11-01":
                 XCTAssertEqual(totalInWeek.duration, 154671) // ~42.96
+                XCTAssertEqual(totalInWeek.events, 2)
             case "2020-11-08":
                 XCTAssertEqual(totalInWeek.duration, 174440) // ~48.45
+                XCTAssertEqual(totalInWeek.events, 1)
             case "2020-11-15":
                 XCTAssertEqual(totalInWeek.duration, 173543) // ~48.20
+                XCTAssertEqual(totalInWeek.events, 1)
             case "2020-11-22":
                 XCTAssertEqual(totalInWeek.duration, 118142) // ~48.20
+                XCTAssertEqual(totalInWeek.events, 0)
             case "2020-11-29":
                 XCTAssertEqual(totalInWeek.duration, 55131) // ~ 32.82
+                XCTAssertEqual(totalInWeek.events, 2)
             default:
                 XCTFail("Unknown category id")
             }
@@ -341,18 +357,23 @@ class Test_Analyzer: XCTestCase {
         let day5Duration: TimeInterval = 60
         
         XCTAssertEqual(results[day1]?.first?.duration ?? 0, day1Duration, accuracy: 1.0)
+        XCTAssertEqual(results[day1]?.first?.events ?? 0, 0)
         XCTAssertEqual(results[day1]?.first?.open ?? false, true)
         
         XCTAssertEqual(results[day2]?.first?.duration ?? 0, day2Duration)
+        XCTAssertEqual(results[day2]?.first?.events ?? 0, 0)
         XCTAssertEqual(results[day2]?.first?.open ?? true, false)
         
         XCTAssertEqual(results[day3]?.first?.duration ?? 0, day3Duration)
+        XCTAssertEqual(results[day3]?.first?.events ?? 0, 0)
         XCTAssertEqual(results[day3]?.first?.open ?? true, false)
         
         XCTAssertEqual(results[day4]?.first?.duration ?? 0, day4Duration)
+        XCTAssertEqual(results[day4]?.first?.events ?? 0, 0)
         XCTAssertEqual(results[day4]?.first?.open ?? true, false)
         
         XCTAssertEqual(results[day5]?.first?.duration ?? 0, day5Duration)
+        XCTAssertEqual(results[day5]?.first?.events ?? 0, 0)
         XCTAssertEqual(results[day5]?.first?.open ?? true, false)
     }
 }

--- a/Shared/Tests/Test_Split.swift
+++ b/Shared/Tests/Test_Split.swift
@@ -19,6 +19,7 @@ class Test_Split: XCTestCase {
             month: 1,
             day: 2,
             duration: 10,
+            events: 5,
             categoryID: 3,
             entryID: 4,
             open: true
@@ -28,6 +29,7 @@ class Test_Split: XCTestCase {
         XCTAssertEqual(split.month, 1)
         XCTAssertEqual(split.day, 2)
         XCTAssertEqual(split.duration, 10)
+        XCTAssertEqual(split.events, 5)
         XCTAssertEqual(split.categoryID, 3)
         XCTAssertEqual(split.entryID, 4)
         XCTAssertEqual(split.open, true)
@@ -48,6 +50,7 @@ class Test_Split: XCTestCase {
             month: 1,
             day: 2,
             duration: 10,
+            events: 5,
             open: false
         )
         
@@ -55,6 +58,7 @@ class Test_Split: XCTestCase {
         XCTAssertEqual(split.month, 1)
         XCTAssertEqual(split.day, 2)
         XCTAssertEqual(split.duration, 10)
+        XCTAssertEqual(split.events, 5)
         XCTAssertEqual(split.categoryID, 3)
         XCTAssertEqual(split.entryID, 4)
         XCTAssertEqual(split.open, false)
@@ -66,6 +70,7 @@ class Test_Split: XCTestCase {
             month: 1,
             day: 2,
             duration: 10,
+            events: 5,
             categoryID: 3,
             entryID: 4,
             open: true
@@ -74,6 +79,7 @@ class Test_Split: XCTestCase {
         let newSplit = Split(
             from: split,
             duration: 20,
+            events: 10,
             categoryID: 30,
             entryID: 40,
             open: false
@@ -83,6 +89,7 @@ class Test_Split: XCTestCase {
         XCTAssertEqual(newSplit.month, 1)
         XCTAssertEqual(newSplit.day, 2)
         XCTAssertEqual(newSplit.duration, 20)
+        XCTAssertEqual(newSplit.events, 10)
         XCTAssertEqual(newSplit.categoryID, 30)
         XCTAssertEqual(newSplit.entryID, 40)
         XCTAssertEqual(newSplit.open, false)
@@ -94,6 +101,7 @@ class Test_Split: XCTestCase {
             month: 1,
             day: 2,
             duration: 10,
+            events: 5,
             categoryID: 3,
             entryID: 4,
             open: true
@@ -105,6 +113,7 @@ class Test_Split: XCTestCase {
         XCTAssertEqual(newSplit.month, 1)
         XCTAssertEqual(newSplit.day, 2)
         XCTAssertEqual(newSplit.duration, 10)
+        XCTAssertEqual(newSplit.events, 5)
         XCTAssertEqual(newSplit.categoryID, 3)
         XCTAssertEqual(newSplit.entryID, 4)
         XCTAssertEqual(newSplit.open, true)

--- a/Shared/Tests/test-analytics.json
+++ b/Shared/Tests/test-analytics.json
@@ -556,5 +556,47 @@
     "started_at_timezone": "America/Chicago",
     "ended_at": "2020-12-01T04:53:27.000Z",
     "ended_at_timezone": "America/Chicago"
+  },
+  {
+    "id": 3129,
+    "type": "event",
+    "category_id": 38,
+    "started_at": "2020-11-15T19:07:58.000Z",
+    "started_at_timezone": "America/Chicago"
+  },
+  {
+    "id": 3130,
+    "type": "event",
+    "category_id": 37,
+    "started_at": "2020-11-30T19:07:58.000Z",
+    "started_at_timezone": "America/Chicago"
+  },
+  {
+    "id": 3131,
+    "type": "event",
+    "category_id": 38,
+    "started_at": "2020-11-30T20:07:58.000Z",
+    "started_at_timezone": "America/Chicago"
+  },
+  {
+    "id": 3132,
+    "type": "event",
+    "category_id": 38,
+    "started_at": "2020-11-06T20:07:58.000Z",
+    "started_at_timezone": "America/Chicago"
+  },
+  {
+    "id": 3133,
+    "type": "event",
+    "category_id": 38,
+    "started_at": "2020-11-06T21:07:58.000Z",
+    "started_at_timezone": "America/Chicago"
+  },
+  {
+    "id": 3134,
+    "type": "event",
+    "category_id": 37,
+    "started_at": "2020-11-08T20:07:58.000Z",
+    "started_at_timezone": "America/Chicago"
   }
 ]

--- a/iOS/iOS.xcodeproj/project.pbxproj
+++ b/iOS/iOS.xcodeproj/project.pbxproj
@@ -41,6 +41,8 @@
 		D8A1B50424CD223000580DCA /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89CEA102482CB07002913AA /* Colors.swift */; };
 		D8A1B50524CD226900580DCA /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89CEA102482CB07002913AA /* Colors.swift */; };
 		D8C533A628EA4E1500F05A92 /* ReportDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C533A528EA4E1500F05A92 /* ReportDocument.swift */; };
+		D8C533A828EA6DCF00F05A92 /* CategoryReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C533A728EA6DCF00F05A92 /* CategoryReport.swift */; };
+		D8C533AA28EA717200F05A92 /* CategoryReportStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C533A928EA717200F05A92 /* CategoryReportStore.swift */; };
 		D8CB930F25CEE79F00C250E9 /* Home.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8CB930E25CEE79F00C250E9 /* Home.swift */; };
 		D8CB931225CEE95C00C250E9 /* Text+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8CB931125CEE95C00C250E9 /* Text+.swift */; };
 		D8CB935125D03FA500C250E9 /* Warehouse.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8CB935025D03FA500C250E9 /* Warehouse.swift */; };
@@ -138,6 +140,8 @@
 		D8977DF425DEB2E400870A9D /* ImportWizard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportWizard.swift; sourceTree = "<group>"; };
 		D89CEA102482CB07002913AA /* Colors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Colors.swift; sourceTree = "<group>"; };
 		D8C533A528EA4E1500F05A92 /* ReportDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportDocument.swift; sourceTree = "<group>"; };
+		D8C533A728EA6DCF00F05A92 /* CategoryReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryReport.swift; sourceTree = "<group>"; };
+		D8C533A928EA717200F05A92 /* CategoryReportStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryReportStore.swift; sourceTree = "<group>"; };
 		D8CB930E25CEE79F00C250E9 /* Home.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Home.swift; sourceTree = "<group>"; };
 		D8CB931125CEE95C00C250E9 /* Text+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Text+.swift"; sourceTree = "<group>"; };
 		D8CB935025D03FA500C250E9 /* Warehouse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Warehouse.swift; sourceTree = "<group>"; };
@@ -279,6 +283,7 @@
 			isa = PBXGroup;
 			children = (
 				D87FCD7628282388009E9C7E /* QuantityMetricReport.swift */,
+				D8C533A728EA6DCF00F05A92 /* CategoryReport.swift */,
 			);
 			name = Reports;
 			sourceTree = "<group>";
@@ -356,6 +361,7 @@
 				D8CB935025D03FA500C250E9 /* Warehouse.swift */,
 				D8977DE425DCB60E00870A9D /* AnalyticsStore.swift */,
 				D8258E42289F193D000E3EF5 /* OtherAnalyticsStore.swift */,
+				D8C533A928EA717200F05A92 /* CategoryReportStore.swift */,
 				D8C533A528EA4E1500F05A92 /* ReportDocument.swift */,
 			);
 			name = Models;
@@ -514,6 +520,7 @@
 				D8A1B50424CD223000580DCA /* Colors.swift in Sources */,
 				D8977DD925DB440900870A9D /* View+NotificationCenter.swift in Sources */,
 				D8258E43289F193D000E3EF5 /* OtherAnalyticsStore.swift in Sources */,
+				D8C533AA28EA717200F05A92 /* CategoryReportStore.swift in Sources */,
 				D8CB935525D06F5D00C250E9 /* MoveCategory.swift in Sources */,
 				D8CB930F25CEE79F00C250E9 /* Home.swift in Sources */,
 				D856E83824D6EFD0001E564A /* Constants.swift in Sources */,
@@ -533,6 +540,7 @@
 				D8977DD725DB3A9900870A9D /* Login.swift in Sources */,
 				D8CB936825D885B500C250E9 /* AccountMenu.swift in Sources */,
 				D856109025CBA44600A325B3 /* ListItem.swift in Sources */,
+				D8C533A828EA6DCF00F05A92 /* CategoryReport.swift in Sources */,
 				D856108E25CB9BDC00A325B3 /* QuantityMetric.swift in Sources */,
 				D8CB936625D8842000C250E9 /* CategoryMenu.swift in Sources */,
 				D8977DF525DEB2E400870A9D /* ImportWizard.swift in Sources */,
@@ -741,7 +749,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 99AECXNBFU;
 				INFOPLIST_FILE = "$(SRCROOT)/iOS/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -762,7 +770,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 99AECXNBFU;
 				INFOPLIST_FILE = "$(SRCROOT)/iOS/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/iOS/iOS/AccountMenu.swift
+++ b/iOS/iOS/AccountMenu.swift
@@ -16,12 +16,18 @@ struct AccountMenu: View {
     enum Selection: Identifiable {
         case addChild
         case rename
+        case analytics
 
         var id: Int { hashValue }
     }
     
     var body: some View {
         Menu {
+            Button(action: {
+                self.selected?(root, .analytics)
+            }, label: {
+                Label("Analytics", systemImage: "chart.xyaxis.line")
+            })
             Button(action: {
                 self.selected?(root, .addChild)
             }, label: {

--- a/iOS/iOS/CategoryMenu.swift
+++ b/iOS/iOS/CategoryMenu.swift
@@ -21,6 +21,7 @@ struct CategoryMenu: View {
         case delete
         case toggleState
         case recordEvent
+        case analytics
 
         var id: Int { hashValue }
     }
@@ -51,6 +52,11 @@ struct CategoryMenu: View {
             } label: {
                 Label("Modify", systemImage: "gear")
             }
+            Button(action: {
+                self.selected?(category, .analytics)
+            }, label: {
+                Label("Analytics", systemImage: "chart.xyaxis.line")
+            })
             Button(action: {
                 self.selected?(category, .recordEvent)
             }, label: {

--- a/iOS/iOS/CategoryReport.swift
+++ b/iOS/iOS/CategoryReport.swift
@@ -1,0 +1,65 @@
+//
+//  CategoryReport.swift
+//  iOS
+//
+//  Created by Nathan Tornquist on 10/2/22.
+//  Copyright © 2022 nathantornquist. All rights reserved.
+//
+
+import SwiftUI
+import TimeSDK
+import Charts
+
+struct CategoryReport: View {
+    @EnvironmentObject var warehouse: Warehouse
+    @StateObject var store: CategoryReportStore
+    
+    @Binding var show: Bool
+    
+    var body: some View {
+        NavigationView {
+            VStack {
+                if store.graphData.count > 0 {
+                    Chart {
+                        ForEach(self.store.graphData) { entry in
+                            BarMark(
+                                x: .value("Date", entry.date, unit: .day),
+                                y: .value("Duration", entry.duration)
+                            )
+                            .foregroundStyle(by: .value("Type", entry.category))
+                        }
+                    }
+                    .chartXAxis {
+                        AxisMarks(values: .stride(by: .weekOfYear))
+                    }
+                    .chartYAxis {
+                        AxisMarks(values: .automatic(desiredCount: 4)) { value in
+                            AxisGridLine()
+
+                            let formatter: DateComponentsFormatter = {
+                                let formatter = DateComponentsFormatter()
+                                formatter.unitsStyle = .abbreviated
+                                formatter.allowedUnits = [.hour]
+                                return formatter
+                            }()
+
+                            if let timeInterval = value.as(TimeInterval.self), let formatted = formatter.string(from: timeInterval) {
+                                AxisValueLabel(formatted)
+                            }
+                        }
+                    }
+                } else {
+                    Text("No data")
+                }
+            }
+            .navigationTitle(self.store.title)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Done") {
+                        self.show = false
+                    }
+                }
+            }
+        }
+    }
+}

--- a/iOS/iOS/CategoryReport.swift
+++ b/iOS/iOS/CategoryReport.swift
@@ -16,40 +16,89 @@ struct CategoryReport: View {
     
     @Binding var show: Bool
     
+    // TODO: Remove need to keep init in sync with store
+    @State var rangeSelection: CategoryReportStore.RangeOption = .month
+    @State var groupBySelection: TimePeriod = .day
+    
     var body: some View {
         NavigationView {
-            VStack {
-                if store.graphData.count > 0 {
-                    Chart {
-                        ForEach(self.store.graphData) { entry in
-                            BarMark(
-                                x: .value("Date", entry.date, unit: .day),
-                                y: .value("Duration", entry.duration)
-                            )
-                            .foregroundStyle(by: .value("Type", entry.category))
-                        }
-                    }
-                    .chartXAxis {
-                        AxisMarks(values: .stride(by: .weekOfYear))
-                    }
-                    .chartYAxis {
-                        AxisMarks(values: .automatic(desiredCount: 4)) { value in
-                            AxisGridLine()
-
-                            let formatter: DateComponentsFormatter = {
-                                let formatter = DateComponentsFormatter()
-                                formatter.unitsStyle = .abbreviated
-                                formatter.allowedUnits = [.hour]
-                                return formatter
-                            }()
-
-                            if let timeInterval = value.as(TimeInterval.self), let formatted = formatter.string(from: timeInterval) {
-                                AxisValueLabel(formatted)
+            List {
+                Section {
+                    if store.graphData.count > 0 {
+                        Chart {
+                            ForEach(self.store.graphData) { entry in
+                                BarMark(
+                                    x: .value("Date", entry.date, unit: .day),
+                                    y: .value("Duration", entry.duration)
+                                )
+                                .foregroundStyle(by: .value("Type", entry.category))
                             }
                         }
+                        .chartXAxis {
+                            if rangeSelection == .all {
+                                AxisMarks(values: .stride(by: .year))
+                            } else if rangeSelection == .year {
+                                AxisMarks(values: .stride(by: .month))
+                            } else {
+                                AxisMarks(values: .stride(by: .weekOfYear))
+                            }
+                        }
+                        .chartYAxis {
+                            AxisMarks(values: .automatic(desiredCount: 4)) { value in
+                                AxisGridLine()
+                                
+                                let formatter: DateComponentsFormatter = {
+                                    let formatter = DateComponentsFormatter()
+                                    formatter.unitsStyle = .abbreviated
+                                    formatter.allowedUnits = [.hour]
+                                    return formatter
+                                }()
+                                
+                                if let timeInterval = value.as(TimeInterval.self), let formatted = formatter.string(from: timeInterval) {
+                                    AxisValueLabel(formatted)
+                                }
+                            }
+                        }
+                        .frame(height: 300)
+                    } else {
+                        HStack {
+                            Spacer()
+                            Text("No data")
+                                .italic()
+                                .foregroundColor(Color(UIColor.placeholderText))
+                            Spacer()
+                        }
                     }
-                } else {
-                    Text("No data")
+                        
+                    Picker("Range", selection: $rangeSelection) {
+                        Text("All").tag(CategoryReportStore.RangeOption.all)
+                        Text("Year").tag(CategoryReportStore.RangeOption.year)
+                        Text("Month").tag(CategoryReportStore.RangeOption.month)
+                        Text("Week").tag(CategoryReportStore.RangeOption.week)
+                    }
+                    .onChange(of: rangeSelection, perform: { newValue in
+                        self.store.recompute(range: self.rangeSelection, gropuBy: self.groupBySelection)
+                    })
+                    .pickerStyle(SegmentedPickerStyle())
+                    .listRowInsets(EdgeInsets())
+                    .padding(EdgeInsets(top: 0, leading: 4, bottom: 0, trailing: 4))
+                    .listRowSeparator(.hidden)
+                    
+                    Picker("Group By", selection: $groupBySelection) {
+                        Text("Year").tag(TimePeriod.year)
+                        Text("Month").tag(TimePeriod.month)
+                        Text("Week").tag(TimePeriod.week)
+                        Text("Day").tag(TimePeriod.day)
+                    }
+                    .onChange(of: groupBySelection, perform: { newValue in
+                        self.store.recompute(range: self.rangeSelection, gropuBy: self.groupBySelection)
+                    })
+                    .pickerStyle(SegmentedPickerStyle())
+                    .listRowInsets(EdgeInsets())
+                    .padding(EdgeInsets(top: 0, leading: 4, bottom: 0, trailing: 4))
+                    .listRowSeparator(.hidden)
+                }  header: {
+                    Text("Historical Data")
                 }
             }
             .navigationTitle(self.store.title)

--- a/iOS/iOS/CategoryReport.swift
+++ b/iOS/iOS/CategoryReport.swift
@@ -19,13 +19,51 @@ struct CategoryReport: View {
     // TODO: Remove need to keep init in sync with store
     @State var rangeSelection: CategoryReportStore.RangeOption = .month
     @State var groupBySelection: TimePeriod = .day
-    
+        
     enum GraphStyle: String {
         case bar = "bar"
         case line = "line"
         case point = "point"
     }
     @State var graphStyle: GraphStyle = .bar
+    
+    var barWidth: MarkDimension {
+        switch rangeSelection {
+        case .week, .month:
+            return .automatic
+        case .threeMonths, .sixMonths:
+            switch groupBySelection {
+            case .year:
+                return .fixed(9.0)
+            case .month:
+                return .fixed(8.0)
+            case .week:
+                return .fixed(7.0)
+            case .day:
+                return .automatic
+            }
+        case .year:
+            switch groupBySelection {
+            case .year, .month:
+                return .fixed(9.0)
+            case .week:
+                return .fixed(3.0)
+            case .day:
+                return .automatic
+            }
+        case .all: // These values are based on ~5 years of data. Should be dynamic
+            switch groupBySelection {
+            case .year:
+                return .fixed(9.0)
+            case .month:
+                return .fixed(2.0)
+            case .week:
+                return .fixed(0.7)
+            case .day:
+                return .automatic
+            }
+        }
+    }
     
     let chartHeight: CGFloat = 300
     
@@ -49,7 +87,8 @@ struct CategoryReport: View {
                                 ForEach(self.store.graphData) { entry in
                                     BarMark(
                                         x: .value("Date", entry.date, unit: .day),
-                                        y: .value("Duration", entry.duration)
+                                        y: .value("Duration", entry.duration),
+                                        width: barWidth
                                     )
                                     .foregroundStyle(by: .value("Type", entry.category))
                                 }
@@ -75,7 +114,7 @@ struct CategoryReport: View {
                         .chartXAxis {
                             if rangeSelection == .all {
                                 AxisMarks(values: .stride(by: .year))
-                            } else if rangeSelection == .year {
+                            } else if rangeSelection == .year || rangeSelection == .threeMonths || rangeSelection == .sixMonths {
                                 AxisMarks(values: .stride(by: .month))
                             } else {
                                 AxisMarks(values: .stride(by: .weekOfYear))
@@ -116,6 +155,8 @@ struct CategoryReport: View {
                     Picker("Timeframe", selection: $rangeSelection) {
                         Text("All time").tag(CategoryReportStore.RangeOption.all)
                         Text("Last Year").tag(CategoryReportStore.RangeOption.year)
+                        Text("Last 6 Months").tag(CategoryReportStore.RangeOption.sixMonths)
+                        Text("Last 3 Months").tag(CategoryReportStore.RangeOption.threeMonths)
                         Text("Last Month").tag(CategoryReportStore.RangeOption.month)
                         Text("Last Week").tag(CategoryReportStore.RangeOption.week)
                     }

--- a/iOS/iOS/CategoryReport.swift
+++ b/iOS/iOS/CategoryReport.swift
@@ -71,6 +71,7 @@ struct CategoryReport: View {
                                 }
                             }
                         }
+                        .chartXScale(domain: self.store.startRange...self.store.endRange)
                         .chartXAxis {
                             if rangeSelection == .all {
                                 AxisMarks(values: .stride(by: .year))

--- a/iOS/iOS/CategoryReport.swift
+++ b/iOS/iOS/CategoryReport.swift
@@ -65,6 +65,24 @@ struct CategoryReport: View {
         }
     }
     
+    @State var showWorkRuler: Bool = false
+    var workRulerPlacement: TimeInterval {
+        switch groupBySelection {
+        case .day:
+            return 28800 // 8 hours
+        case .week:
+            return 144000 // 40 hours
+        default:
+            return 0
+        }
+    }
+    var enableWorkRuler: Bool {
+        return self.groupBySelection == .day || self.groupBySelection == .week
+    }
+    var workRulerTitle: String {
+        return self.groupBySelection == .day ? "8h" : "40h"
+    }
+    
     let chartHeight: CGFloat = 300
     
     var body: some View {
@@ -109,6 +127,20 @@ struct CategoryReport: View {
                                     .foregroundStyle(by: .value("Type", entry.category))
                                 }
                             }
+                            
+                            if self.showWorkRuler && self.enableWorkRuler {
+                                RuleMark(
+                                    /* TODO: Averages: by included day for work? */
+                                    y: .value("Average", self.workRulerPlacement)
+                                )
+                                .foregroundStyle(.green)
+                                .lineStyle(StrokeStyle(lineWidth: 1.5, dash: [3, 5]))
+                                .annotation(position: .trailing, alignment: .leading) {
+                                    Text(self.workRulerTitle)
+                                        .font(.caption2)
+                                        .foregroundStyle(.green)
+                                }
+                            }
                         }
                         .chartXScale(domain: self.store.startRange...self.store.endRange)
                         .chartXAxis {
@@ -127,7 +159,7 @@ struct CategoryReport: View {
                                 let formatter: DateComponentsFormatter = {
                                     let formatter = DateComponentsFormatter()
                                     formatter.unitsStyle = .abbreviated
-                                    formatter.allowedUnits = [.hour]
+                                    formatter.allowedUnits = [.hour, .minute]
                                     return formatter
                                 }()
                                 
@@ -182,6 +214,13 @@ struct CategoryReport: View {
                         Text("Scatterplot").tag(GraphStyle.point)
                     }
                     .pickerStyle(.menu)
+                    
+                    HStack {
+                        Toggle(isOn: $showWorkRuler, label: {
+                            Text("Work Ruler")
+                        })
+                        .disabled(self.enableWorkRuler == false)
+                    }
                 } header:  {
                     Text("Controls")
                 }

--- a/iOS/iOS/CategoryReportStore.swift
+++ b/iOS/iOS/CategoryReportStore.swift
@@ -41,6 +41,8 @@ class CategoryReportStore: ObservableObject {
     enum RangeOption: String {
         case all = "all"
         case year = "year"
+        case sixMonths = "six_months"
+        case threeMonths = "three_months"
         case month = "month"
         case week = "week"
     }
@@ -93,7 +95,19 @@ class CategoryReportStore: ObservableObject {
             var allResults: [String: [Analyzer.Result]] = [:]
             if self.range == .all {
                 allResults = Time.shared.analyzer.evaluateAll(
-                    gropuBy: self.groupBy,
+                    groupBy: self.groupBy,
+                    perform: [.calculatePerCategory],
+                    includeEmpty: true
+                )
+            } else if self.range == .sixMonths || self.range == .threeMonths {
+                let shift = self.range == .sixMonths ? 6 : 3
+                let startRange = Calendar.current.date(byAdding: .month, value: -shift, to: Date())!
+                
+                allResults = Time.shared.analyzer.evaluate(
+                    from: startRange,
+                    to: nil,
+                    in: Calendar.current,
+                    groupBy: self.groupBy,
                     perform: [.calculatePerCategory],
                     includeEmpty: true
                 )

--- a/iOS/iOS/CategoryReportStore.swift
+++ b/iOS/iOS/CategoryReportStore.swift
@@ -1,0 +1,116 @@
+//
+//  CategoryReportStore.swift
+//  iOS
+//
+//  Created by Nathan Tornquist on 10/2/22.
+//  Copyright © 2022 nathantornquist. All rights reserved.
+//
+
+import Foundation
+import Combine
+import SwiftUI
+import TimeSDK
+
+struct CategoryReportGraphValue: Equatable, Identifiable {
+    var stringDate: String
+    var date: Date
+    var category: String
+    var duration: TimeInterval
+    
+    var id: String {
+        return "\(stringDate)-\(category)-\(duration)"
+    }
+}
+
+class CategoryReportStore: ObservableObject {
+    @Published var warehouse: Warehouse
+    @Binding var rootCategory: TimeSDK.Category?
+    
+    @Published var title: String = "Analytics"
+    @Published var graphData: [CategoryReportGraphValue] = []
+    
+    init(for warehouse: Warehouse, category: Binding<TimeSDK.Category?>) {
+        self.warehouse = warehouse
+        self._rootCategory = category
+        
+        // Bump to end of thread to let binding resolve -- Needs correct implementation.
+        DispatchQueue.main.async {
+            self.compute()
+        }
+    }
+    
+    func reset() {
+        Mainify {
+            self.title = "Analytics"
+        }
+    }
+    
+    func compute() {
+        DispatchQueue.global(qos: .background).async {
+            guard let categoryID = self.rootCategory?.id,
+                  let categoryTree = Time.shared.store.categoryTrees.map({ (key: Int, value: CategoryTree) in
+                      return value.findItem(withID: categoryID)
+                  }).filter({ $0 != nil }).first,
+                  let categoryTree = categoryTree
+            else {
+                self.reset()
+                return
+            }
+
+            // Identify Scope
+            let inScopeCategoryIDs = categoryTree.listCategoryTrees().map { $0.id }
+            
+            // Calculate General Metrics
+            let allResults = Time.shared.analyzer.evaluate(
+                TimeRange(rolling: .month),
+                groupBy: .day,
+                perform: [.calculatePerCategory],
+                includeEmpty: true
+            )
+            var inScopeResults: [String: [Analyzer.Result]] = [:]
+            allResults.keys.forEach { key in
+                inScopeResults[key] = allResults[key]!.filter({ result in
+                    guard let categoryID = result.categoryID else { return false }
+                    return inScopeCategoryIDs.contains(categoryID)
+                })
+            }
+            
+            // Format for graph
+            var nameCache: [Int: String] = [:]
+            inScopeCategoryIDs.forEach { categoryID in
+                nameCache[categoryID] = self.warehouse.getName(for: categoryID)
+            }
+            
+            let dateFormatter = DateFormatter()
+            dateFormatter.dateFormat = "yyyy-MM-dd"
+            dateFormatter.timeZone = TimeZone.current // Sync with analyzer
+            dateFormatter.locale = Locale.current // Sync with analyzer
+            
+            let graphData = inScopeResults.flatMap { (key: String, value: [Analyzer.Result]) -> [CategoryReportGraphValue] in
+                guard let date = dateFormatter.date(from: key) else {
+                    return []
+                }
+                
+                let unsortedGraphData = value.map({ result in
+                    return CategoryReportGraphValue(
+                        stringDate: key,
+                        date: date,
+                        category: nameCache[result.categoryID ?? -1] ?? "Unknwon",
+                        duration: result.duration
+                    )
+                })
+                    
+                let sortedGraphData = unsortedGraphData.sorted { a, b in
+                    return a.category.localizedCompare(b.category) == .orderedAscending
+                }
+                
+                return sortedGraphData
+            }
+                        
+            DispatchQueue.main.async {
+                self.title = self.rootCategory?.name ?? "Analytics"
+                self.graphData = graphData
+            }
+        }
+    }
+}

--- a/iOS/iOS/CategoryReportStore.swift
+++ b/iOS/iOS/CategoryReportStore.swift
@@ -162,12 +162,13 @@ class CategoryReportStore: ObservableObject {
             // Should always safely resolve
             let first = (orderedKeys.first != nil ? dateFormatter.date(from: orderedKeys.first!) : nil) ?? Date()
             let last = (orderedKeys.last != nil ? dateFormatter.date(from: orderedKeys.last!) : nil) ?? Date()
+            let lastInclusive = Calendar.current.date(byAdding: .day, value: 1, to: last)!
             
-            DispatchQueue.main.async {  
+            DispatchQueue.main.async {
                 self.title = (self.rootCategory?.parentID != nil ? self.rootCategory?.name : nil) ?? "Analytics"
                 self.graphData = graphData
                 self.startRange = first
-                self.endRange = last
+                self.endRange = lastInclusive
                 
                 self.loading = false
             }

--- a/iOS/iOS/Entries.swift
+++ b/iOS/iOS/Entries.swift
@@ -62,6 +62,9 @@ struct Entries: View {
                 action: active ? .stop : .none,
                 active: active,
                 loading: handlingId[entry.id] ?? false,
+                onTapText: {
+                    self.selectedEntry = entry
+                },
                 onTapButton: {
                     if active {
                         Mainify {
@@ -73,9 +76,6 @@ struct Entries: View {
                     }
                 }
             )
-            .onTapGesture {
-                self.selectedEntry = entry
-            }
         }
         .listStyle(.inset)
         .sheet(

--- a/iOS/iOS/Entries.swift
+++ b/iOS/iOS/Entries.swift
@@ -62,7 +62,7 @@ struct Entries: View {
                 action: active ? .stop : .none,
                 active: active,
                 loading: handlingId[entry.id] ?? false,
-                onTap: {
+                onTapButton: {
                     if active {
                         Mainify {
                             handlingId[entry.id] = true

--- a/iOS/iOS/Home.swift
+++ b/iOS/iOS/Home.swift
@@ -34,7 +34,8 @@ struct Home: View {
         case rename
         case delete
         case importList
-        case report
+        case metricReport
+        case categoryReport
         
         static func from(_ selection: AccountMenu.Selection) -> HomeModal? {
             switch selection {
@@ -55,6 +56,8 @@ struct Home: View {
                 return HomeModal.rename
             case .delete:
                 return HomeModal.delete
+            case .analytics:
+                return HomeModal.categoryReport
             default:
                 return nil
             }
@@ -90,7 +93,7 @@ struct Home: View {
                 .padding(EdgeInsets())
                 .contentShape(Rectangle())
                 .onTapGesture {
-                    self.showModal = .report
+                    self.showModal = .metricReport
                 }
                 
                 if self.warehouse.recentCategories.count > 0 {
@@ -174,7 +177,7 @@ struct Home: View {
     
     func handleCategoryAction(category: TimeSDK.Category, categoryAction: CategoryMenu.Selection) {
         switch categoryAction {
-        case .addChild, .move, .rename, .delete:
+        case .addChild, .move, .rename, .delete, .analytics:
             self.showModal = HomeModal.from(categoryAction)
             self.selectedCategory = category
         case .toggleState:
@@ -227,7 +230,7 @@ struct Home: View {
                 ImportList(model: ImportModel(for: self.warehouse), show: buildBinding(for: .importList))
                     .environmentObject(self.warehouse)
             )
-        case .report:
+        case .metricReport:
             return AnyView(
                 QuantityMetricReport(
                     store: OtherAnalyticsStore(for: self.warehouse),
@@ -236,6 +239,16 @@ struct Home: View {
                 )
                 .environmentObject(self.warehouse)
             )
+        case .categoryReport:
+            return AnyView(
+                CategoryReport(
+                    store: CategoryReportStore(
+                        for: self.warehouse,
+                        category: $selectedCategory),
+                    show: buildBinding(for: .categoryReport)
+                )
+                    .environmentObject(self.warehouse)
+           )
         }
     }
 }

--- a/iOS/iOS/Home.swift
+++ b/iOS/iOS/Home.swift
@@ -16,7 +16,7 @@ struct Home: View {
     @State var showModal: HomeModal? = nil
     @State var showAlert: HomeAlert? = nil
     @State var selectedCategory: TimeSDK.Category? = nil
-    @State var metricShowDay: Bool? = nil
+    @State var metricDefaultGroupBy: TimePeriod? = nil
     var signOut: (() -> ())? = nil
     
     @EnvironmentObject var warehouse: Warehouse
@@ -88,8 +88,8 @@ struct Home: View {
                     MetricSection(
                         store: AnalyticsStore(for: self.warehouse),
                         showSeconds: showSeconds,
-                        dayAction: { handleMetricAction(tappedDay: true) },
-                        weekAction: { handleMetricAction(tappedDay: false) }
+                        dayAction: { handleMetricAction(groupBy: .day) },
+                        weekAction: { handleMetricAction(groupBy: .week) }
                     )
                 }
                 .listRowInsets(EdgeInsets())
@@ -189,8 +189,8 @@ struct Home: View {
         }
     }
     
-    func handleMetricAction(tappedDay: Bool) {
-        self.metricShowDay = tappedDay
+    func handleMetricAction(groupBy: TimePeriod? = nil) {
+        self.metricDefaultGroupBy = groupBy
         self.showModal = .metricReport
     }
     
@@ -242,11 +242,7 @@ struct Home: View {
                 QuantityMetricReport(
                     store: OtherAnalyticsStore(
                         for: self.warehouse,
-                        groupBy: (
-                            self.metricShowDay == true
-                            ? TimePeriod.day
-                            : (self.metricShowDay == false ? TimePeriod.week : nil)
-                        )
+                        groupBy: self.metricDefaultGroupBy
                     ),
                     show: buildBinding(for: .importList),
                     showSeconds: showSeconds
@@ -258,11 +254,15 @@ struct Home: View {
                 CategoryReport(
                     store: CategoryReportStore(
                         for: self.warehouse,
-                        category: $selectedCategory),
-                    show: buildBinding(for: .categoryReport)
+                        category: $selectedCategory,
+                        defaultRange: .month, // Pair with below for init data loading
+                        defaultGroupBy: .day
+                    ),
+                    show: buildBinding(for: .categoryReport),
+                    rangeSelection: .month,
+                    groupBySelection: .day
                 )
-                    .environmentObject(self.warehouse)
-           )
+            )
         }
     }
 }

--- a/iOS/iOS/Home.swift
+++ b/iOS/iOS/Home.swift
@@ -98,7 +98,7 @@ struct Home: View {
                 
                 if self.warehouse.recentCategories.count > 0 {
                     Section(header: Text("Recents").titleStyle()) {
-                        RecentSection()
+                        RecentSection(categoryAction: handleCategoryAction)
                     }
                     .listRowInsets(EdgeInsets())
                 }

--- a/iOS/iOS/Home.swift
+++ b/iOS/iOS/Home.swift
@@ -172,6 +172,9 @@ struct Home: View {
             self.selectedCategory = category
         case .rename:
             break // No actions yet
+        case .analytics:
+            self.showModal = .categoryReport
+            self.selectedCategory = category
         }
     }
     

--- a/iOS/iOS/MetricSection.swift
+++ b/iOS/iOS/MetricSection.swift
@@ -18,6 +18,9 @@ struct MetricSection: View {
     }
     
     let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
+    
+    var dayAction: (() -> Void)? = nil
+    var weekAction: (() -> Void)? = nil
         
     var body: some View {
         Group {
@@ -33,6 +36,10 @@ struct MetricSection: View {
                     )
                 })
             )
+            .contentShape(Rectangle())
+            .onTapGesture {
+                dayAction?()
+            }
             QuantityMetric(
                 total: store.weekTotal?.displayDuration(withSeconds: showSeconds) ?? emptyDuration,
                 description: "This Week",
@@ -45,6 +52,10 @@ struct MetricSection: View {
                     )
                 })
             )
+            .contentShape(Rectangle())
+            .onTapGesture {
+                weekAction?()
+            }
         }.onReceive(timer, perform: { _ in
             store.refreshAsNeeded()
         })

--- a/iOS/iOS/MetricSection.swift
+++ b/iOS/iOS/MetricSection.swift
@@ -31,7 +31,7 @@ struct MetricSection: View {
                     QuantityMetric.QuantityItem(
                         id: result.categoryID ?? self.warehouse.getName(for: result.categoryID).hashValue,
                         name: self.warehouse.getName(for: result.categoryID),
-                        total: result.displayDuration(withSeconds: showSeconds),
+                        total: result.displayDurationAndOrEvents(withSeconds: showSeconds),
                         active: result.open
                     )
                 })
@@ -47,7 +47,7 @@ struct MetricSection: View {
                     QuantityMetric.QuantityItem(
                         id: result.categoryID ?? self.warehouse.getName(for: result.categoryID).hashValue,
                         name: self.warehouse.getName(for: result.categoryID),
-                        total: result.displayDuration(withSeconds: showSeconds),
+                        total: result.displayDurationAndOrEvents(withSeconds: showSeconds),
                         active: result.open
                     )
                 })

--- a/iOS/iOS/OtherAnalyticsStore.swift
+++ b/iOS/iOS/OtherAnalyticsStore.swift
@@ -132,7 +132,7 @@ class OtherAnalyticsStore: ObservableObject {
     
     private func calculateMetrics() {
         let updatedData = Time.shared.analyzer.evaluateAll(
-            gropuBy: self.groupBy, perform: [.calculateTotal, .calculatePerCategory], includeEmpty: self.includeEmpty
+            groupBy: self.groupBy, perform: [.calculateTotal, .calculatePerCategory], includeEmpty: self.includeEmpty
         )
         
         let startingKeys = self.orderedKeys

--- a/iOS/iOS/OtherAnalyticsStore.swift
+++ b/iOS/iOS/OtherAnalyticsStore.swift
@@ -47,9 +47,9 @@ class OtherAnalyticsStore: ObservableObject {
     
     var cancellables = [AnyCancellable]()
     
-    init(for warehouse: Warehouse) {
+    init(for warehouse: Warehouse, groupBy: TimePeriod? = nil) {
         // Load groupBy first for single-pass analytics
-        self.groupBy = TimePeriod(
+        self.groupBy = groupBy ?? TimePeriod(
             rawValue: UserDefaults().string(forKey: self.storeGroupByKey) ?? ""
         ) ?? .week
         

--- a/iOS/iOS/QuantityMetricReport.swift
+++ b/iOS/iOS/QuantityMetricReport.swift
@@ -39,7 +39,7 @@ struct QuantityMetricReport: View {
                             QuantityMetric.QuantityItem(
                                 id: result.categoryID ?? self.warehouse.getName(for: result.categoryID).hashValue,
                                 name: self.warehouse.getName(for: result.categoryID),
-                                total: result.displayDuration(withSeconds: internalShowSeconds),
+                                total: result.displayDurationAndOrEvents(withSeconds: internalShowSeconds),
                                 active: result.open
                             )
                         }) ?? []

--- a/iOS/iOS/RecentSection.swift
+++ b/iOS/iOS/RecentSection.swift
@@ -42,6 +42,8 @@ struct RecentSection: View {
                     categoryAction?(categoryTree.node, .analytics)
                 },
                 onTapButton: {
+                    // This is in-line instead of using categoryAction so that
+                    // the loading states can be tightly coupled.
                     Mainify {
                         handlingId[categoryTree.id] = true
                     }

--- a/iOS/iOS/TitleSubtitleActionView.swift
+++ b/iOS/iOS/TitleSubtitleActionView.swift
@@ -14,7 +14,8 @@ struct TitleSubtitleActionView: View {
     var action: Action
     var active: Bool
     var loading: Bool
-    var onTap: (() -> ())? = nil
+    var onTapText: (() -> ())? = nil
+    var onTapButton: (() -> ())? = nil
     
     enum Action {
         case play
@@ -36,20 +37,20 @@ struct TitleSubtitleActionView: View {
     
     var body: some View {
         HStack {
-            VStack(alignment: .center, spacing: 8, content: {
-                HStack {
+            HStack {
+                VStack(alignment: .leading, spacing: 8, content: {
                     Text(title)
                         .font(Font.system(size: 17.0))
                         .foregroundColor(self.active ? Color(Colors.active) : Color(.label))
-                    Spacer()
-                }
-                HStack {
                     Text(subtitle)
                         .font(Font.system(size: 12.0))
                         .foregroundColor(Color(.label))
-                    Spacer()
-                }
-            })
+                })
+                Spacer()
+            }
+            .onTapGesture {
+                onTapText?()
+            }
             Spacer()
             if loading {
                 VStack {
@@ -62,7 +63,7 @@ struct TitleSubtitleActionView: View {
                 VStack {
                     Spacer()
                     Button(action: {
-                        onTap?()
+                        onTapButton?()
                     }) {
                         Text(Image(systemName: self.action.icon ?? "questionmark"))
                             .imageScale(.large)


### PR DESCRIPTION
## Analytics (graph data)

* Introduce analytics view to show recorded range and event data
    * Not really "analytics", just a graph of the data
* Supports week, month, 3mo, 6mo, all time graph ranges
* Support group by day, week, month and year
* Suppport line, scatter and bar charts
* Support optional 8hr or 40hr horizontal rule when looking at time ranges (for standard work rates)
* Some graphing issues in swift charts
    * No horizontal scrolling with pinned y axis
	* No dual y axis
	* Y axis labels are a bit unreliable (and truncate)
	* X axis is automatic, which means often it's strange hours/minutes splits
	* --> It's fast to good, but slow to great. This is very good for my own use
* Due to the dual y-axis limitations, events and ranges are shown on separate graphs
    * A switcher is shown when both data types exist in a given time period, otherwise it just shows the available graph

## Other UX Changes

* Tapping "day" or "week" metrics shows that value by default
   * Masks "last used" behind this preference.
* Tapping a recent's title/subtitle text opens analytics for that tree
* Analytics for a specific tree can be opened from the account or category menu
* TitleSubtitleActionView has intentional middle space (may impact potential text wrapping) so that the tap areas are clearer.

## Data Changes

* Add support for events to Analyzer
   * Add events count to Split (base analyzer shard, but slightly misnamed now)
   * Count events in "closed entries" (renamed from closed ranges)
   * Recompute cache on event changes
   * Update tests for event changes
* Add `displayDurationAndOrEvents` to Range
   * `x event(s)` when just events
   * `xx:xx:xx` when just ranges
   * `(y) xx:xx:xx` when mixed data -- should be uncommon
   * Not the best method name, but it works for now.
      * The app is range-focused. This brings events in, but not in the same priority.